### PR TITLE
Add mpg123 1.25.10 as portlib for 3ds, ppc and switch

### DIFF
--- a/3ds/mpg123/PKGBUILD
+++ b/3ds/mpg123/PKGBUILD
@@ -1,0 +1,44 @@
+# Maintainer: Gabriel Kind <gabriel-dkp mastergk de>
+
+pkgname=3ds-mpg123
+pkgver=1.25.10
+pkgrel=1
+pkgdesc="A real time MPEG audio decoder for layer 1, 2 and 3"
+arch=('any')
+url="http://sourceforge.net/projects/mpg123"
+license=('LGPL2.1')
+options=(!strip libtool staticlibs)
+source=(
+ "http://downloads.sourceforge.net/sourceforge/mpg123/mpg123-${pkgver}.tar.bz2"
+ "mpg123-1.25.10.patch"
+)
+sha256sums=('6c1337aee2e4bf993299851c70b7db11faec785303cfca3a5c3eb5f329ba7023'
+            '57cd203fdd92d4441eb5639859c50efe9018e3e5d10ee240a6e06fd9a24ae508')
+makedepends=('devkitpro-pkgbuild-helpers')
+
+build() {
+  cd mpg123-$pkgver
+
+  source /opt/devkitpro/devkitarm.sh
+  source /opt/devkitpro/3dsvars.sh
+
+  patch -Np1 -i "$srcdir"/mpg123-${pkgver}.patch
+
+  autoreconf -fi
+
+  ./configure --prefix="${PORTLIBS_PREFIX}" --host=arm-none-eabi \
+    --disable-shared --enable-static --enable-fifo=no \
+    --enable-ipv6=no --enable-network=no --enable-int-quality=no \
+    --with-cpu=generic --with-default-audio=dummy
+
+  make
+}
+
+package() {
+  cd mpg123-$pkgver
+
+  make DESTDIR="$pkgdir" install
+
+  # remove useless stuff
+  rm -rf "$pkgdir"${PORTLIBS_PREFIX}/bin "$pkgdir"${PORTLIBS_PREFIX}/share
+}

--- a/3ds/mpg123/mpg123-1.25.10.patch
+++ b/3ds/mpg123/mpg123-1.25.10.patch
@@ -1,0 +1,63 @@
+diff -Naur mpg123-1.25.10-old/configure.ac mpg123-1.25.10/configure.ac
+--- mpg123-1.25.10-old/configure.ac	2017-08-29 01:49:00.661996762 +0200
++++ mpg123-1.25.10/configure.ac	2017-08-29 01:49:41.609026671 +0200
+@@ -1217,6 +1217,20 @@
+ #	AC_DEFINE( 
+ #fi
+ 
++if test x"$ac_cv_header_sys_signal_h" = xyes; then
++	AC_CHECK_FUNCS( sigemptyset sigaddset sigprocmask sigaction )
++	if test x"$ac_cv_func_sigemptyset" = xno ||
++	   test x"$ac_cv_func_sigaddset" = xno ||
++	   test x"$ac_cv_func_sigprocmask" = xno ||
++	   test x"$ac_cv_func_sigaction" = xno; then
++		AC_DEFINE(DONT_CATCH_SIGNALS, 1, [ Signal handling is not supported on this platform ])
++	fi
++else
++	AC_DEFINE(DONT_CATCH_SIGNALS, 1, [ Signal handling is not supported on this platform ])
++fi
++
++AC_CHECK_FUNCS( sleep, [ have_sleep=yes ], [ have_sleep=no ] )
++
+ dnl ############## Choose compiler flags and CPU
+ 
+ # do not assume gcc here, so no flags by default
+--- mpg123-1.25.10-old/src/control_generic.c	2017-08-29 01:49:00.668663487 +0200
++++ mpg123-1.25.10/src/control_generic.c	2017-08-29 01:50:15.649329482 +0200
+@@ -28,8 +28,10 @@
+ #include <ctype.h>
+ #if !defined (WIN32) || defined (__CYGWIN__)
+ #include <sys/wait.h>
++#ifdef NETWORK
+ #include <sys/socket.h>
+ #endif
++#endif
+ #include <errno.h>
+ #include <string.h>
+ 
+@@ -311,8 +313,11 @@
+  		outstream = stderr;
+  	else
+  		outstream = stdout;
+- 		
+-#ifndef WIN32
++
++#if 1
++	fprintf(outstream, "The control interface is not supported on this platform\n");
++	return 0;
++#elif !defined(WIN32)
+  	setlinebuf(outstream);
+ #else /* perhaps just use setvbuf as it's C89 */
+ 	/*
+diff -Naur mpg123-1.25.10-old/src/mpg123.c mpg123-1.25.10/src/mpg123.c
+--- mpg123-1.25.10-old/src/mpg123.c	2017-08-29 01:49:00.668663487 +0200
++++ mpg123-1.25.10/src/mpg123.c	2017-08-29 01:49:54.475807710 +0200
+@@ -1239,6 +1239,8 @@
+ 			if(param.verbose > 2) fprintf(stderr, "Note: pausing %i seconds before next track.\n", param.delay);
+ #ifdef WIN32
+ 			Sleep(param.delay*1000);
++#elif !defined(HAVE_SLEEP)
++			fprintf(stderr, "sleep not supported on this platform\n");
+ #else
+ 			sleep(param.delay);
+ #endif

--- a/ppc/mpg123/PKGBUILD
+++ b/ppc/mpg123/PKGBUILD
@@ -1,0 +1,46 @@
+# Maintainer: Gabriel Kind <gabriel-dkp mastergk de>
+
+pkgname=ppc-mpg123
+pkgver=1.25.10
+pkgrel=1
+pkgdesc="A real time MPEG audio decoder for layer 1, 2 and 3"
+arch=('any')
+url="http://sourceforge.net/projects/mpg123"
+license=('LGPL2.1')
+options=(!strip libtool staticlibs)
+source=(
+ "http://downloads.sourceforge.net/sourceforge/mpg123/mpg123-${pkgver}.tar.bz2"
+ "mpg123-1.25.10.patch"
+)
+sha256sums=('6c1337aee2e4bf993299851c70b7db11faec785303cfca3a5c3eb5f329ba7023'
+            '57cd203fdd92d4441eb5639859c50efe9018e3e5d10ee240a6e06fd9a24ae508')
+makedepends=('devkitpro-pkgbuild-helpers')
+
+build() {
+  cd mpg123-$pkgver
+
+  source /opt/devkitpro/devkitppc.sh
+  source /opt/devkitpro/ppcvars.sh
+
+  patch -Np1 -i "$srcdir"/mpg123-${pkgver}.patch
+
+  autoreconf -fi
+
+  ./configure --prefix="${PORTLIBS_PREFIX}" --host=powerpc-eabi \
+    --disable-shared --enable-static --enable-fifo=no \
+    --enable-ipv6=no --enable-network=no --enable-int-quality=no \
+    --with-cpu=generic --with-default-audio=dummy
+
+  make
+}
+
+package() {
+  cd mpg123-$pkgver
+
+  source /opt/devkitpro/devkitppc.sh
+
+  make DESTDIR="$pkgdir" install
+
+  # remove useless stuff
+  rm -rf "$pkgdir"${PORTLIBS_PREFIX}/bin "$pkgdir"${PORTLIBS_PREFIX}/share
+}

--- a/ppc/mpg123/mpg123-1.25.10.patch
+++ b/ppc/mpg123/mpg123-1.25.10.patch
@@ -1,0 +1,63 @@
+diff -Naur mpg123-1.25.10-old/configure.ac mpg123-1.25.10/configure.ac
+--- mpg123-1.25.10-old/configure.ac	2017-08-29 01:49:00.661996762 +0200
++++ mpg123-1.25.10/configure.ac	2017-08-29 01:49:41.609026671 +0200
+@@ -1217,6 +1217,20 @@
+ #	AC_DEFINE( 
+ #fi
+ 
++if test x"$ac_cv_header_sys_signal_h" = xyes; then
++	AC_CHECK_FUNCS( sigemptyset sigaddset sigprocmask sigaction )
++	if test x"$ac_cv_func_sigemptyset" = xno ||
++	   test x"$ac_cv_func_sigaddset" = xno ||
++	   test x"$ac_cv_func_sigprocmask" = xno ||
++	   test x"$ac_cv_func_sigaction" = xno; then
++		AC_DEFINE(DONT_CATCH_SIGNALS, 1, [ Signal handling is not supported on this platform ])
++	fi
++else
++	AC_DEFINE(DONT_CATCH_SIGNALS, 1, [ Signal handling is not supported on this platform ])
++fi
++
++AC_CHECK_FUNCS( sleep, [ have_sleep=yes ], [ have_sleep=no ] )
++
+ dnl ############## Choose compiler flags and CPU
+ 
+ # do not assume gcc here, so no flags by default
+--- mpg123-1.25.10-old/src/control_generic.c	2017-08-29 01:49:00.668663487 +0200
++++ mpg123-1.25.10/src/control_generic.c	2017-08-29 01:50:15.649329482 +0200
+@@ -28,8 +28,10 @@
+ #include <ctype.h>
+ #if !defined (WIN32) || defined (__CYGWIN__)
+ #include <sys/wait.h>
++#ifdef NETWORK
+ #include <sys/socket.h>
+ #endif
++#endif
+ #include <errno.h>
+ #include <string.h>
+ 
+@@ -311,8 +313,11 @@
+  		outstream = stderr;
+  	else
+  		outstream = stdout;
+- 		
+-#ifndef WIN32
++
++#if 1
++	fprintf(outstream, "The control interface is not supported on this platform\n");
++	return 0;
++#elif !defined(WIN32)
+  	setlinebuf(outstream);
+ #else /* perhaps just use setvbuf as it's C89 */
+ 	/*
+diff -Naur mpg123-1.25.10-old/src/mpg123.c mpg123-1.25.10/src/mpg123.c
+--- mpg123-1.25.10-old/src/mpg123.c	2017-08-29 01:49:00.668663487 +0200
++++ mpg123-1.25.10/src/mpg123.c	2017-08-29 01:49:54.475807710 +0200
+@@ -1239,6 +1239,8 @@
+ 			if(param.verbose > 2) fprintf(stderr, "Note: pausing %i seconds before next track.\n", param.delay);
+ #ifdef WIN32
+ 			Sleep(param.delay*1000);
++#elif !defined(HAVE_SLEEP)
++			fprintf(stderr, "sleep not supported on this platform\n");
+ #else
+ 			sleep(param.delay);
+ #endif

--- a/switch/mpg123/PKGBUILD
+++ b/switch/mpg123/PKGBUILD
@@ -1,0 +1,46 @@
+# Maintainer: Gabriel Kind <gabriel-dkp mastergk de>
+
+pkgname=switch-mpg123
+pkgver=1.25.10
+pkgrel=1
+pkgdesc="A real time MPEG audio decoder for layer 1, 2 and 3"
+arch=('any')
+url="http://sourceforge.net/projects/mpg123"
+license=('LGPL2.1')
+options=(!strip libtool staticlibs)
+source=(
+ "http://downloads.sourceforge.net/sourceforge/mpg123/mpg123-${pkgver}.tar.bz2"
+ "mpg123-1.25.10.patch"
+)
+sha256sums=('6c1337aee2e4bf993299851c70b7db11faec785303cfca3a5c3eb5f329ba7023'
+            '57cd203fdd92d4441eb5639859c50efe9018e3e5d10ee240a6e06fd9a24ae508')
+makedepends=('devkitpro-pkgbuild-helpers')
+
+build() {
+  cd mpg123-$pkgver
+
+  source /opt/devkitpro/devkita64.sh
+  source /opt/devkitpro/switchvars.sh
+
+  patch -Np1 -i "$srcdir"/mpg123-${pkgver}.patch
+
+  autoreconf -fi
+
+  ./configure --prefix="${PORTLIBS_PREFIX}" --host=aarch64-none-elf \
+    --disable-shared --enable-static --enable-fifo=no \
+    --enable-ipv6=no --enable-network=no --enable-int-quality=no \
+    --with-cpu=generic --with-default-audio=dummy
+
+  make
+}
+
+package() {
+  cd mpg123-$pkgver
+
+  source /opt/devkitpro/devkita64.sh
+
+  make DESTDIR="$pkgdir" install
+
+  # remove useless stuff
+  rm -rf "$pkgdir"${PORTLIBS_PREFIX}/bin "$pkgdir"${PORTLIBS_PREFIX}/share
+}

--- a/switch/mpg123/mpg123-1.25.10.patch
+++ b/switch/mpg123/mpg123-1.25.10.patch
@@ -1,0 +1,63 @@
+diff -Naur mpg123-1.25.10-old/configure.ac mpg123-1.25.10/configure.ac
+--- mpg123-1.25.10-old/configure.ac	2017-08-29 01:49:00.661996762 +0200
++++ mpg123-1.25.10/configure.ac	2017-08-29 01:49:41.609026671 +0200
+@@ -1217,6 +1217,20 @@
+ #	AC_DEFINE( 
+ #fi
+ 
++if test x"$ac_cv_header_sys_signal_h" = xyes; then
++	AC_CHECK_FUNCS( sigemptyset sigaddset sigprocmask sigaction )
++	if test x"$ac_cv_func_sigemptyset" = xno ||
++	   test x"$ac_cv_func_sigaddset" = xno ||
++	   test x"$ac_cv_func_sigprocmask" = xno ||
++	   test x"$ac_cv_func_sigaction" = xno; then
++		AC_DEFINE(DONT_CATCH_SIGNALS, 1, [ Signal handling is not supported on this platform ])
++	fi
++else
++	AC_DEFINE(DONT_CATCH_SIGNALS, 1, [ Signal handling is not supported on this platform ])
++fi
++
++AC_CHECK_FUNCS( sleep, [ have_sleep=yes ], [ have_sleep=no ] )
++
+ dnl ############## Choose compiler flags and CPU
+ 
+ # do not assume gcc here, so no flags by default
+--- mpg123-1.25.10-old/src/control_generic.c	2017-08-29 01:49:00.668663487 +0200
++++ mpg123-1.25.10/src/control_generic.c	2017-08-29 01:50:15.649329482 +0200
+@@ -28,8 +28,10 @@
+ #include <ctype.h>
+ #if !defined (WIN32) || defined (__CYGWIN__)
+ #include <sys/wait.h>
++#ifdef NETWORK
+ #include <sys/socket.h>
+ #endif
++#endif
+ #include <errno.h>
+ #include <string.h>
+ 
+@@ -311,8 +313,11 @@
+  		outstream = stderr;
+  	else
+  		outstream = stdout;
+- 		
+-#ifndef WIN32
++
++#if 1
++	fprintf(outstream, "The control interface is not supported on this platform\n");
++	return 0;
++#elif !defined(WIN32)
+  	setlinebuf(outstream);
+ #else /* perhaps just use setvbuf as it's C89 */
+ 	/*
+diff -Naur mpg123-1.25.10-old/src/mpg123.c mpg123-1.25.10/src/mpg123.c
+--- mpg123-1.25.10-old/src/mpg123.c	2017-08-29 01:49:00.668663487 +0200
++++ mpg123-1.25.10/src/mpg123.c	2017-08-29 01:49:54.475807710 +0200
+@@ -1239,6 +1239,8 @@
+ 			if(param.verbose > 2) fprintf(stderr, "Note: pausing %i seconds before next track.\n", param.delay);
+ #ifdef WIN32
+ 			Sleep(param.delay*1000);
++#elif !defined(HAVE_SLEEP)
++			fprintf(stderr, "sleep not supported on this platform\n");
+ #else
+ 			sleep(param.delay);
+ #endif


### PR DESCRIPTION
Best library for mp3 playback.

The patch disables the unused player cli interface (needs command line stuff) and network functionality.

No idea what the network code does, I guess MPEG file streaming from a website?
Though I created this port years ago when there was no socket code in newlib so can't say if it works by now. (Patches welcome if anybody really needs this)

Dependency for SDL2 mixer if anybody wants to port this :+1: 