### PR TITLE
Added libuuid and wolfSSL Switch portlibs

### DIFF
--- a/switch/libuuid/.gitignore
+++ b/switch/libuuid/.gitignore
@@ -1,0 +1,1 @@
+switch-libuuid

--- a/switch/libuuid/PKGBUILD
+++ b/switch/libuuid/PKGBUILD
@@ -6,6 +6,7 @@ url='https://sourceforge.net/projects/libuuid'
 license=('GPL-2.0')
 options=(!strip libtool staticlibs)
 source=("https://github.com/natinusala/switch-libuuid/archive/$pkgver.zip")
+groups=('switch-portlibs')
 
 sha256sums=('287ca3e61dc9e70839dcb8be2654f739a6696ce843d41b6c05e07f75a2e55fcd')
 

--- a/switch/libuuid/PKGBUILD
+++ b/switch/libuuid/PKGBUILD
@@ -1,0 +1,32 @@
+pkgname=switch-libuuid
+pkgver=4af5d5971d8cdf5ee733ae38fb7fc7f8da85b989
+pkgrel=1
+arch=('any')
+url='https://sourceforge.net/projects/libuuid'
+license=('GPL-2.0')
+options=(!strip libtool staticlibs)
+source=("https://github.com/natinusala/switch-libuuid/archive/$pkgver.zip")
+
+sha256sums=('287ca3e61dc9e70839dcb8be2654f739a6696ce843d41b6c05e07f75a2e55fcd')
+
+build() {
+  cd switch-libuuid-$pkgver
+  
+  autoreconf -vfi
+
+  source /opt/devkitpro/devkita64.sh
+  source /opt/devkitpro/switchvars.sh
+  
+  ./configure --prefix=$PORTLIBS_PREFIX --host=aarch64-none-elf --disable-shared --enable-static CFLAGS="-UHAVE_UUIDD"
+  
+  make
+}
+
+package() {
+  cd switch-libuuid-$pkgver
+
+  source /opt/devkitpro/devkita64.sh
+  source /opt/devkitpro/switchvars.sh
+
+  make DESTDIR="$pkgdir" install
+}

--- a/switch/wolfssl/.gitignore
+++ b/switch/wolfssl/.gitignore
@@ -1,0 +1,1 @@
+switch-wolfssl

--- a/switch/wolfssl/PKGBUILD
+++ b/switch/wolfssl/PKGBUILD
@@ -8,6 +8,7 @@ license=('GPL-2.0')
 options=(!strip libtool staticlibs)
 depends=()
 makedepends=('patch')
+groups=('switch-portlibs')
 source=(
     "https://github.com/wolfSSL/wolfssl/archive/$pkgver.zip"
     "wolfssl-${pkgver}-csrng-wc_GenerateSeed.patch"

--- a/switch/wolfssl/PKGBUILD
+++ b/switch/wolfssl/PKGBUILD
@@ -1,0 +1,43 @@
+pkgname=switch-wolfssl
+pkgver=bea0e6142a2a0ca9b3c81a08c3d116a98e8762c7
+pkgrel=1
+pkgdesc='wolfSSL (formerly CyaSSL) is a small, fast, portable implementation of TLS/SSL for embedded devices to the cloud.'
+arch=('any')
+url='http://www.wolfssl.com'
+license=('GPL-2.0')
+options=(!strip libtool staticlibs)
+depends=()
+makedepends=('patch')
+source=(
+    "https://github.com/wolfSSL/wolfssl/archive/$pkgver.zip"
+    "wolfssl-${pkgver}-csrng-wc_GenerateSeed.patch"
+)
+
+sha256sums=(
+    '71e2db94d0416d1f4af6651d1605fa74fc9065baee6a6ad9fa462b70df11b019'
+    'd83a83ff8fb757d471dca6e038a1f3a315aeea32dd761b00d1040e9acb1b2b4b'
+)
+
+build() {
+  cd wolfssl-$pkgver
+  
+  patch -Np1 -i "$srcdir/wolfssl-${pkgver}-csrng-wc_GenerateSeed.patch"
+  
+  autoreconf -vfi
+  
+  source /opt/devkitpro/devkita64.sh
+  source /opt/devkitpro/switchvars.sh
+  
+  ./configure --prefix=$PORTLIBS_PREFIX --host=aarch64-none-elf --disable-examples --enable-harden --disable-shared --enable-static --enable-certgen --enable-opensslextra --enable-pwdbased --enable-keygen --enable-sslv3 CFLAGS="-DNO_DEV_RANDOM -DNO_WRITEV -DTFM_TIMING_RESISTANT -fPIC"
+  
+  make src/libwolfssl.la
+}
+
+package() {
+  cd wolfssl-$pkgver
+
+  source /opt/devkitpro/devkita64.sh
+  source /opt/devkitpro/switchvars.sh
+
+  make DESTDIR="$pkgdir" install
+}

--- a/switch/wolfssl/README.md
+++ b/switch/wolfssl/README.md
@@ -1,6 +1,6 @@
 # switch-wolfssl
 
-You **will* need to initialize `csrng` in your homebrew to use wolfSSL :
+You **will** need to initialize `csrng` in your homebrew to use wolfSSL :
 
 ```
 csrngInitialize();

--- a/switch/wolfssl/README.md
+++ b/switch/wolfssl/README.md
@@ -1,0 +1,11 @@
+# switch-wolfssl
+
+You **will* need to initialize `csrng` in your homebrew to use wolfSSL :
+
+```
+csrngInitialize();
+
+[...]
+
+csrngExit();
+```

--- a/switch/wolfssl/wolfssl-bea0e6142a2a0ca9b3c81a08c3d116a98e8762c7-csrng-wc_GenerateSeed.patch
+++ b/switch/wolfssl/wolfssl-bea0e6142a2a0ca9b3c81a08c3d116a98e8762c7-csrng-wc_GenerateSeed.patch
@@ -1,0 +1,23 @@
+diff --git a/wolfcrypt/src/random.c b/wolfcrypt/src/random.c
+index 92234de522..70e2550ca5 100644
+--- a/wolfcrypt/src/random.c
++++ b/wolfcrypt/src/random.c
+@@ -1702,14 +1702,13 @@ int wc_GenerateSeed(OS_Seed* os, byte* output, word32 sz)
+ 
+ #elif defined(NO_DEV_RANDOM)
+ 
+-    #error "you need to write an os specific wc_GenerateSeed() here"
+-
+-    /*
++	#include <switch.h>
++ 
+     int wc_GenerateSeed(OS_Seed* os, byte* output, word32 sz)
+     {
+-        return 0;
++        return csrngGetRandomBytes(output, sz);
+     }
+-    */
++    
+ 
+ #else
+ 


### PR DESCRIPTION
wolfSSL is pulled from the official GitHub repository with a patch applied to use `csrng` as a seed generator.

I wasn't able to build just libuuid from linux-utils (gettext was not friendly), so I pulled it from a SourceForge repository and adapted ; the final code is hosted there : https://github.com/natinusala/switch-libuuid (it doesn't use uuidd)

libuuid **is not thread-safe** as I removed the internal clock file lock due to missing `flock` function.