### PR TITLE
Add libfribidi and libass for Switch

### DIFF
--- a/switch/libass/PKGBUILD
+++ b/switch/libass/PKGBUILD
@@ -1,0 +1,42 @@
+# Maintainer: Dave Murphy <davem@devkitpro.org>
+# Contributor: carstene1ns <dev f4ke de>
+
+pkgname=switch-libass
+pkgver=0.14.0
+pkgrel=1
+pkgdesc='A portable subtitle renderer (Nintendo Switch port)'
+arch=('any')
+url="https://github.com/libass/libass"
+license=('custom: ISC')
+options=(!strip staticlibs)
+depends=('switch-freetype' 'switch-libfribidi')
+makedepends=('switch-pkg-config' 'devkitpro-pkgbuild-helpers')
+source=("https://github.com/libass/libass/releases/download/$pkgver/libass-$pkgver.tar.xz")
+sha256sums=('881f2382af48aead75b7a0e02e65d88c5ebd369fe46bc77d9270a94aa8fd38a2')
+groups=('switch-portlibs')
+
+build() {
+  cd libass-$pkgver
+
+  source /opt/devkitpro/devkita64.sh
+  source /opt/devkitpro/switchvars.sh
+
+  ./configure --prefix="$PORTLIBS_PREFIX" --host=aarch64-none-elf \
+    --disable-shared --enable-static \
+    --disable-asm --enable-large-tiles \
+    --disable-require-system-font-provider
+
+  make
+}
+
+package() {
+  cd libass-$pkgver
+
+  source /opt/devkitpro/devkita64.sh
+  source /opt/devkitpro/switchvars.sh
+
+  make DESTDIR="$pkgdir" install
+
+  # license
+  install -Dm644 "COPYING" "$pkgdir/$PORTLIBS_PREFIX/licenses/$pkgname/COPYING"
+}

--- a/switch/libfribidi/PKGBUILD
+++ b/switch/libfribidi/PKGBUILD
@@ -1,0 +1,45 @@
+# Maintainer: Dave Murphy <davem@devkitpro.org>
+# Contributor: carstene1ns <dev f4ke de>
+
+pkgname=switch-libfribidi
+pkgver=1.0.4
+pkgrel=1
+pkgdesc='Free Implementation of the Unicode Bidirectional Algorithm (Nintendo Switch port)'
+arch=('any')
+url="https://github.com/fribidi/fribidi"
+license=('LGPL2.1')
+options=(!strip staticlibs)
+makedepends=('switch-pkg-config' 'devkitpro-pkgbuild-helpers')
+source=("https://github.com/fribidi/fribidi/releases/download/v$pkgver/fribidi-$pkgver.tar.bz2")
+sha256sums=('94bdfe553e004d8bd095b109e182682311dd511740d5083326d1582f1df237be')
+groups=('switch-portlibs')
+
+prepare() {
+  cd fribidi-$pkgver
+  # patch out binaries, as they conflict with getopt and do not work anyway
+  sed '/^SUBDIRS/ s/bin //' -i Makefile.am
+}
+
+build() {
+  cd fribidi-$pkgver
+
+  source /opt/devkitpro/devkita64.sh
+  source /opt/devkitpro/switchvars.sh
+
+  ./configure --prefix="$PORTLIBS_PREFIX" --host=aarch64-none-elf \
+    --disable-shared --enable-static
+
+  make
+}
+
+package() {
+  cd fribidi-$pkgver
+
+  source /opt/devkitpro/devkita64.sh
+  source /opt/devkitpro/switchvars.sh
+
+  make DESTDIR="$pkgdir" install
+
+  # remove documentation
+  rm -fr "$pkgdir"${PORTLIBS_PREFIX}/share
+}


### PR DESCRIPTION
Some notes:
Currently `libass` with `--disable-require-system-font-provider` is not really usable OOTB, because font finding and selection will not work automatically. However, fontconfig might be a bit much to have. Thought about hardcoding the shared_font or something, but this can also be done from the app using it.

Btw. I do not know if you you intend to build packages from OSX, since `sed` usage in fribidi-prepare() is not portable. Might be worth a note in the README that real `.patch`es are preferred.