### PR TITLE
Fix 3ds-libvorbis dependency

### DIFF
--- a/3ds/libvorbis/PKGBUILD
+++ b/3ds/libvorbis/PKGBUILD
@@ -3,13 +3,13 @@
 
 pkgname=3ds-libvorbis
 pkgver=1.3.5
-pkgrel=1
+pkgrel=2
 pkgdesc='Vorbis is a patent-clear, fully open, general purpose audio encoding format standard that rivals or even surpasses the 'upcoming' generation of proprietary codecs (AAC and TwinVQ, also known as VQF).'
 arch=('any')
 url='https://wiki.xiph.org/Vorbis'
 license=(Xiph.org)
 options=(!strip libtool staticlibs)
-depends=('switch-libogg')
+depends=('3ds-libogg')
 makedepends=('devkitpro-pkgbuild-helpers' '3ds-pkg-config')
 groups=('3ds-portlibs')
 source=("https://ftp.osuosl.org/pub/xiph/releases/vorbis/libvorbis-$pkgver.tar.gz")


### PR DESCRIPTION
I don't think the 3ds-libvorbis needs the switch-libogg, but rather 3ds-libogg.
Also set pkgrel one higher since there was a package info change.