### PR TITLE
Add libopus

### DIFF
--- a/3ds/libopus/PKGBUILD
+++ b/3ds/libopus/PKGBUILD
@@ -1,0 +1,32 @@
+# Maintainer:  Dave Murphy <davem@devkitpro.org>
+
+pkgname=3ds-libopus
+pkgver=1.2.1
+pkgrel=1
+pkgdesc='Reference implementation of the lossy audio codec, Opus'
+arch=('any')
+url='https://opus-codec.org/'
+license=(BSD)
+options=(!strip libtool staticlibs)
+source=("https://archive.mozilla.org/pub/opus/opus-$pkgver.tar.gz")
+sha256sums=('cfafd339ccd9c5ef8d6ab15d7e1a412c054bf4cb4ecbbbcc78c12ef2def70732')
+makedepends=('3ds-pkg-config' 'devkitpro-pkgbuild-helpers')
+
+build() {
+  cd opus-$pkgver
+
+  source /opt/devkitpro/3dsvars.sh
+
+  ./configure --prefix="${PORTLIBS_PREFIX}" --host=arm-none-eabi \
+    --disable-shared --enable-static
+
+  make
+}
+
+package() {
+  cd opus-$pkgver
+
+  source /opt/devkitpro/3dsvars.sh
+
+  make DESTDIR="$pkgdir" install
+}


### PR DESCRIPTION
This adds libopus for the 3ds. No idea why this wasn't made before (it was available when dkp used portlibs and was made avliable for the switch).

Please let me know if anything needs to be changed or fixed.