### PR TITLE
Add opusfile

### DIFF
--- a/3ds/opusfile/PKGBUILD
+++ b/3ds/opusfile/PKGBUILD
@@ -1,0 +1,32 @@
+# Maintainer:  Dave Murphy <davem@devkitpro.org>
+
+pkgname=3ds-opusfile
+pkgver=0.10
+pkgrel=1
+pkgdesc='Library for opening, seeking, and decoding .opus files'
+arch=('any')
+url='https://opus-codec.org/'
+license=(BSD)
+options=(!strip libtool staticlibs)
+source=("https://downloads.xiph.org/releases/opus/opusfile-$pkgver.tar.gz")
+sha256sums=('48e03526ba87ef9cf5f1c47b5ebe3aa195bd89b912a57060c36184a6cd19412f')
+makedepends=('3ds-pkg-config' 'devkitpro-pkgbuild-helpers' '3ds-libogg' '3ds-libopus')
+
+build() {
+  cd opusfile-$pkgver
+
+  source /opt/devkitpro/3dsvars.sh
+
+  ./configure --prefix="${PORTLIBS_PREFIX}" --host=arm-none-eabi \
+    --disable-shared --enable-static
+
+  make
+}
+
+package() {
+  cd opusfile-$pkgver
+
+  source /opt/devkitpro/3dsvars.sh
+
+  make DESTDIR="$pkgdir" install
+}


### PR DESCRIPTION
Requires libopus. Also was apart of dkp-portlibs but was never carried over.