### PR TITLE
ppc: Add libmad

### DIFF
--- a/ppc/libmad/PKGBUILD
+++ b/ppc/libmad/PKGBUILD
@@ -15,7 +15,7 @@ source=("ftp://ftp.mars.org/pub/mpeg/libmad-${pkgver}.tar.gz"
         "frame_length.patch" "pkg-config.patch" "optimise.diff")
 sha256sums=("bbfac3ed6bfbc2823d3775ebb931087371e142bb0e9bb1bee51a76a6e0078690"
             "e54439c7efa6fc7272923d8507d79ee2992b115225baed1c47d1704e442e3c24"
-            "1616cddc2b5f0700ad65605fe826c0d21ed3f0892f214e9ff895d947346d1d36"
+            "0d22d5fe2785502ab1a731e185ad7ccbcdd575220337a99a36683aa9aaeb8072"
             "269505f22d700f3f00bcc97706f75889fbc6f7acf99cf068f0939b287bb50966")
 
 prepare() {
@@ -24,15 +24,13 @@ prepare() {
     patch -p1 -i "$srcdir/pkg-config.patch"
     patch -p1 -i "$srcdir/frame_length.patch"
     patch -p1 -i "$srcdir/optimise.diff"
+    autoreconf -fi
+
 }
 
 build() {
     cd libmad-$pkgver
     source /opt/devkitpro/ppcvars.sh
-
-    # We changed configure.ac above
-    touch NEWS AUTHORS ChangeLog
-    autoconf
 
     ./configure --prefix="$PORTLIBS_PREFIX" --host=powerpc-eabi --disable-shared
 

--- a/ppc/libmad/PKGBUILD
+++ b/ppc/libmad/PKGBUILD
@@ -1,0 +1,49 @@
+# Maintainer: Dave Murphy <davem@devkitpro.org>
+# Contributor: Ash Logan <ash [at] heyquark [dot] com>
+
+pkgname=ppc-libmad
+pkgver=0.15.1b
+pkgrel=1
+pkgdesc="High-quality MPEG audio decoder"
+url="https://www.underbit.com/products/mad/"
+license=("GPLv2")
+arch=("any")
+depends=("devkitPPC")
+makedepends=("ppc-pkg-config" "devkitpro-pkgbuild-helpers")
+options=("!buildflags" "staticlibs" "libtool" "!strip")
+source=("ftp://ftp.mars.org/pub/mpeg/libmad-${pkgver}.tar.gz"
+        "frame_length.patch" "pkg-config.patch" "optimise.diff")
+sha256sums=("bbfac3ed6bfbc2823d3775ebb931087371e142bb0e9bb1bee51a76a6e0078690"
+            "e54439c7efa6fc7272923d8507d79ee2992b115225baed1c47d1704e442e3c24"
+            "1616cddc2b5f0700ad65605fe826c0d21ed3f0892f214e9ff895d947346d1d36"
+            "269505f22d700f3f00bcc97706f75889fbc6f7acf99cf068f0939b287bb50966")
+
+prepare() {
+    cd libmad-$pkgver
+
+    patch -p1 -i "$srcdir/pkg-config.patch"
+    patch -p1 -i "$srcdir/frame_length.patch"
+    patch -p1 -i "$srcdir/optimise.diff"
+}
+
+build() {
+    cd libmad-$pkgver
+    source /opt/devkitpro/ppcvars.sh
+
+    # We changed configure.ac above
+    touch NEWS AUTHORS ChangeLog
+    autoconf
+
+    ./configure --prefix="$PORTLIBS_PREFIX" --host=powerpc-eabi --disable-shared
+
+    make
+}
+
+package() {
+    cd libmad-$pkgver
+    source /opt/devkitpro/ppcvars.sh
+
+    make DESTDIR="$pkgdir" install
+
+    install -Dm644 COPYRIGHT "$pkgdir/$PORTLIBS_PREFIX/licenses/$pkgname/COPYRIGHT"
+}

--- a/ppc/libmad/frame_length.patch
+++ b/ppc/libmad/frame_length.patch
@@ -1,0 +1,197 @@
+; https://git.archlinux.org/svntogit/packages.git/tree/trunk/frame_length.diff?h=packages/libmad
+; You can calculate where the next frame will start depending on things
+; like the bitrate. See mad_header_decode().  It seems that when decoding
+; the frame you can go past that boundary.  This attempts to catch those cases,
+; but might not catch all of them.
+; For more info see http://bugs.debian.org/508133
+Index: libmad-0.15.1b/layer12.c
+===================================================================
+--- libmad-0.15.1b.orig/layer12.c	2008-12-23 21:38:07.000000000 +0100
++++ libmad-0.15.1b/layer12.c	2008-12-23 21:38:12.000000000 +0100
+@@ -134,6 +134,12 @@
+   for (sb = 0; sb < bound; ++sb) {
+     for (ch = 0; ch < nch; ++ch) {
+       nb = mad_bit_read(&stream->ptr, 4);
++	if (mad_bit_nextbyte(&stream->ptr) > stream->next_frame)
++	{
++		stream->error = MAD_ERROR_LOSTSYNC;
++		stream->sync = 0;
++		return -1;
++	}
+
+       if (nb == 15) {
+ 	stream->error = MAD_ERROR_BADBITALLOC;
+@@ -146,6 +152,12 @@
+
+   for (sb = bound; sb < 32; ++sb) {
+     nb = mad_bit_read(&stream->ptr, 4);
++	if (mad_bit_nextbyte(&stream->ptr) > stream->next_frame)
++	{
++		stream->error = MAD_ERROR_LOSTSYNC;
++		stream->sync = 0;
++		return -1;
++	}
+
+     if (nb == 15) {
+       stream->error = MAD_ERROR_BADBITALLOC;
+@@ -162,6 +174,12 @@
+     for (ch = 0; ch < nch; ++ch) {
+       if (allocation[ch][sb]) {
+ 	scalefactor[ch][sb] = mad_bit_read(&stream->ptr, 6);
++	if (mad_bit_nextbyte(&stream->ptr) > stream->next_frame)
++	{
++		stream->error = MAD_ERROR_LOSTSYNC;
++		stream->sync = 0;
++		return -1;
++	}
+
+ # if defined(OPT_STRICT)
+ 	/*
+@@ -187,6 +205,12 @@
+ 	frame->sbsample[ch][s][sb] = nb ?
+ 	  mad_f_mul(I_sample(&stream->ptr, nb),
+ 		    sf_table[scalefactor[ch][sb]]) : 0;
++	if (mad_bit_nextbyte(&stream->ptr) > stream->next_frame)
++	{
++		stream->error = MAD_ERROR_LOSTSYNC;
++		stream->sync = 0;
++		return -1;
++	}
+       }
+     }
+
+@@ -195,6 +219,12 @@
+ 	mad_fixed_t sample;
+
+ 	sample = I_sample(&stream->ptr, nb);
++	if (mad_bit_nextbyte(&stream->ptr) > stream->next_frame)
++	{
++		stream->error = MAD_ERROR_LOSTSYNC;
++		stream->sync = 0;
++		return -1;
++	}
+
+ 	for (ch = 0; ch < nch; ++ch) {
+ 	  frame->sbsample[ch][s][sb] =
+@@ -403,7 +433,15 @@
+     nbal = bitalloc_table[offsets[sb]].nbal;
+
+     for (ch = 0; ch < nch; ++ch)
++    {
+       allocation[ch][sb] = mad_bit_read(&stream->ptr, nbal);
++	if (mad_bit_nextbyte(&stream->ptr) > stream->next_frame)
++	{
++		stream->error = MAD_ERROR_LOSTSYNC;
++		stream->sync = 0;
++		return -1;
++	}
++    }
+   }
+
+   for (sb = bound; sb < sblimit; ++sb) {
+@@ -411,6 +449,13 @@
+
+     allocation[0][sb] =
+     allocation[1][sb] = mad_bit_read(&stream->ptr, nbal);
++
++	if (mad_bit_nextbyte(&stream->ptr) > stream->next_frame)
++	{
++		stream->error = MAD_ERROR_LOSTSYNC;
++		stream->sync = 0;
++		return -1;
++	}
+   }
+
+   /* decode scalefactor selection info */
+@@ -419,6 +464,12 @@
+     for (ch = 0; ch < nch; ++ch) {
+       if (allocation[ch][sb])
+ 	scfsi[ch][sb] = mad_bit_read(&stream->ptr, 2);
++	if (mad_bit_nextbyte(&stream->ptr) > stream->next_frame)
++	{
++		stream->error = MAD_ERROR_LOSTSYNC;
++		stream->sync = 0;
++		return -1;
++	}
+     }
+   }
+
+@@ -442,6 +493,12 @@
+     for (ch = 0; ch < nch; ++ch) {
+       if (allocation[ch][sb]) {
+ 	scalefactor[ch][sb][0] = mad_bit_read(&stream->ptr, 6);
++	if (mad_bit_nextbyte(&stream->ptr) > stream->next_frame)
++	{
++		stream->error = MAD_ERROR_LOSTSYNC;
++		stream->sync = 0;
++		return -1;
++	}
+
+ 	switch (scfsi[ch][sb]) {
+ 	case 2:
+@@ -452,11 +509,23 @@
+
+ 	case 0:
+ 	  scalefactor[ch][sb][1] = mad_bit_read(&stream->ptr, 6);
++		if (mad_bit_nextbyte(&stream->ptr) > stream->next_frame)
++		{
++			stream->error = MAD_ERROR_LOSTSYNC;
++			stream->sync = 0;
++			return -1;
++		}
+ 	  /* fall through */
+
+ 	case 1:
+ 	case 3:
+ 	  scalefactor[ch][sb][2] = mad_bit_read(&stream->ptr, 6);
++		if (mad_bit_nextbyte(&stream->ptr) > stream->next_frame)
++		{
++			stream->error = MAD_ERROR_LOSTSYNC;
++			stream->sync = 0;
++			return -1;
++		}
+ 	}
+
+ 	if (scfsi[ch][sb] & 1)
+@@ -488,6 +557,12 @@
+ 	  index = offset_table[bitalloc_table[offsets[sb]].offset][index - 1];
+
+ 	  II_samples(&stream->ptr, &qc_table[index], samples);
++		if (mad_bit_nextbyte(&stream->ptr) > stream->next_frame)
++		{
++			stream->error = MAD_ERROR_LOSTSYNC;
++			stream->sync = 0;
++			return -1;
++		}
+
+ 	  for (s = 0; s < 3; ++s) {
+ 	    frame->sbsample[ch][3 * gr + s][sb] =
+@@ -506,6 +581,12 @@
+ 	index = offset_table[bitalloc_table[offsets[sb]].offset][index - 1];
+
+ 	II_samples(&stream->ptr, &qc_table[index], samples);
++	if (mad_bit_nextbyte(&stream->ptr) > stream->next_frame)
++	{
++		stream->error = MAD_ERROR_LOSTSYNC;
++		stream->sync = 0;
++		return -1;
++	}
+
+ 	for (ch = 0; ch < nch; ++ch) {
+ 	  for (s = 0; s < 3; ++s) {
+Index: libmad-0.15.1b/layer3.c
+===================================================================
+--- libmad-0.15.1b.orig/layer3.c	2008-12-23 21:38:07.000000000 +0100
++++ libmad-0.15.1b/layer3.c	2008-12-23 21:38:12.000000000 +0100
+@@ -2608,6 +2608,12 @@
+     next_md_begin = 0;
+
+   md_len = si.main_data_begin + frame_space - next_md_begin;
++  if (md_len + MAD_BUFFER_GUARD > MAD_BUFFER_MDLEN)
++  {
++	stream->error = MAD_ERROR_LOSTSYNC;
++	stream->sync = 0;
++	return -1;
++  }
+
+   frame_used = 0;

--- a/ppc/libmad/optimise.diff
+++ b/ppc/libmad/optimise.diff
@@ -1,0 +1,78 @@
+; https://git.archlinux.org/svntogit/packages.git/tree/trunk/optimize.diff?h=packages/libmad
+Index: libmad-0.15.1b/configure.ac
+===================================================================
+--- libmad-0.15.1b.orig/configure.ac	2008-03-07 20:31:23.000000000 +0000
++++ libmad-0.15.1b/configure.ac	2008-03-07 20:34:26.000000000 +0000
+@@ -124,71 +124,7 @@
+
+ if test "$GCC" = yes
+ then
+-    if test -z "$arch"
+-    then
+-	case "$host" in
+-	    i386-*)           ;;
+-	    i?86-*)           arch="-march=i486" ;;
+-	    arm*-empeg-*)     arch="-march=armv4 -mtune=strongarm1100" ;;
+-	    armv4*-*)         arch="-march=armv4 -mtune=strongarm" ;;
+-	    powerpc-*)        ;;
+-	    mips*-agenda-*)   arch="-mcpu=vr4100" ;;
+-	    mips*-luxsonor-*) arch="-mips1 -mcpu=r3000 -Wa,-m4010" ;;
+-	esac
+-    fi
+-
+-    case "$optimize" in
+-	-O|"-O "*)
+-	    optimize="-O"
+-	    optimize="$optimize -fforce-mem"
+-	    optimize="$optimize -fforce-addr"
+-	    : #x optimize="$optimize -finline-functions"
+-	    : #- optimize="$optimize -fstrength-reduce"
+-	    optimize="$optimize -fthread-jumps"
+-	    optimize="$optimize -fcse-follow-jumps"
+-	    optimize="$optimize -fcse-skip-blocks"
+-	    : #x optimize="$optimize -frerun-cse-after-loop"
+-	    : #x optimize="$optimize -frerun-loop-opt"
+-	    : #x optimize="$optimize -fgcse"
+-	    optimize="$optimize -fexpensive-optimizations"
+-	    optimize="$optimize -fregmove"
+-	    : #* optimize="$optimize -fdelayed-branch"
+-	    : #x optimize="$optimize -fschedule-insns"
+-	    optimize="$optimize -fschedule-insns2"
+-	    : #? optimize="$optimize -ffunction-sections"
+-	    : #? optimize="$optimize -fcaller-saves"
+-	    : #> optimize="$optimize -funroll-loops"
+-	    : #> optimize="$optimize -funroll-all-loops"
+-	    : #x optimize="$optimize -fmove-all-movables"
+-	    : #x optimize="$optimize -freduce-all-givs"
+-	    : #? optimize="$optimize -fstrict-aliasing"
+-	    : #* optimize="$optimize -fstructure-noalias"
+-
+-	    case "$host" in
+-		arm*-*)
+-		    optimize="$optimize -fstrength-reduce"
+-		    ;;
+-		mips*-*)
+-		    optimize="$optimize -fstrength-reduce"
+-		    optimize="$optimize -finline-functions"
+-		    ;;
+-		i?86-*)
+-		    optimize="$optimize -fstrength-reduce"
+-		    ;;
+-		powerpc-apple-*)
+-		    # this triggers an internal compiler error with gcc2
+-		    : #optimize="$optimize -fstrength-reduce"
+-
+-		    # this is really only beneficial with gcc3
+-		    : #optimize="$optimize -finline-functions"
+-		    ;;
+-		*)
+-		    # this sometimes provokes bugs in gcc 2.95.2
+-		    : #optimize="$optimize -fstrength-reduce"
+-		    ;;
+-	    esac
+-	    ;;
+-    esac
++    optimize="-O2"
+ fi
+
+ case "$host" in

--- a/ppc/libmad/pkg-config.patch
+++ b/ppc/libmad/pkg-config.patch
@@ -1,0 +1,118 @@
+; https://git.archlinux.org/svntogit/packages.git/tree/trunk/libmad.patch?h=packages/libmad
+diff -ruN libmad-0.15.1b.orig/Makefile.am libmad-0.15.1b/Makefile.am
+--- libmad-0.15.1b.orig/Makefile.am	2004-02-17 02:02:03.000000000 +0000
++++ libmad-0.15.1b/Makefile.am	2005-08-25 12:08:04.000000000 +0000
+@@ -33,9 +33,12 @@
+ minimad_INCLUDES =
+ minimad_LDADD =		libmad.la
+
+-EXTRA_DIST =		mad.h.sed  \
++EXTRA_DIST =		mad.h.sed mad.pc.in \
+ 			CHANGES COPYRIGHT CREDITS README TODO VERSION
+
++pkgconfigdir = $(libdir)/pkgconfig
++pkgconfig_DATA= mad.pc
++
+ exported_headers =	version.h fixed.h bit.h timer.h stream.h frame.h  \
+ 			synth.h decoder.h
+
+diff -ruN libmad-0.15.1b.orig/Makefile.in libmad-0.15.1b/Makefile.in
+--- libmad-0.15.1b.orig/Makefile.in	2004-02-17 02:33:23.000000000 +0000
++++ libmad-0.15.1b/Makefile.in	2005-08-25 12:09:34.000000000 +0000
+@@ -14,6 +14,8 @@
+
+ @SET_MAKE@
+
++pkgconfigdir = $(libdir)/pkgconfig
++pkgconfig_DATA = mad.pc
+
+ SOURCES = $(libmad_la_SOURCES) $(EXTRA_libmad_la_SOURCES) $(minimad_SOURCES)
+
+@@ -43,7 +45,7 @@
+ 	$(srcdir)/Makefile.am $(srcdir)/Makefile.in \
+ 	$(srcdir)/config.h.in $(srcdir)/libmad.list.in \
+ 	$(top_srcdir)/configure COPYING INSTALL TODO config.guess \
+-	config.sub depcomp install-sh ltmain.sh missing mkinstalldirs
++	config.sub depcomp install-sh ltmain.sh missing mkinstalldirs mad.pc.in
+ subdir = .
+ ACLOCAL_M4 = $(top_srcdir)/aclocal.m4
+ am__aclocal_m4_deps = $(top_srcdir)/configure.ac
+@@ -53,7 +55,7 @@
+  configure.lineno configure.status.lineno
+ mkinstalldirs = $(SHELL) $(top_srcdir)/mkinstalldirs
+ CONFIG_HEADER = config.h
+-CONFIG_CLEAN_FILES = libmad.list
++CONFIG_CLEAN_FILES = libmad.list mad.pc
+ am__installdirs = $(DESTDIR)$(libdir) $(DESTDIR)$(includedir)
+ libLTLIBRARIES_INSTALL = $(INSTALL)
+ LTLIBRARIES = $(lib_LTLIBRARIES)
+@@ -218,7 +220,7 @@
+ minimad_SOURCES = minimad.c
+ minimad_INCLUDES =
+ minimad_LDADD = libmad.la
+-EXTRA_DIST = mad.h.sed  \
++EXTRA_DIST = mad.h.sed  mad.pc.in \
+ 			CHANGES COPYRIGHT CREDITS README TODO VERSION
+
+ exported_headers = version.h fixed.h bit.h timer.h stream.h frame.h  \
+@@ -298,6 +300,28 @@
+ 	rm -f stamp-h1
+ 	touch $@
+
++mad.pc: $(top_builddir)/config.status mad.pc.in
++	cd $(top_builddir) && CONFIG_FILES=$@ CONFIG_HEADERS= $(SHELL) ./config.status
++
++install-pkgconfigDATA: $(pkgconfig_DATA)
++	@$(NORMAL_INSTALL)
++	$(mkinstalldirs) $(DESTDIR)$(pkgconfigdir)
++	@list='$(pkgconfig_DATA)'; for p in $$list; do \
++	  if test -f $(srcdir)/$$p; then \
++	    echo " $(INSTALL_DATA) $(srcdir)/$$p $(DESTDIR)$(pkgconfigdir)/$$p"; \
++	    $(INSTALL_DATA) $(srcdir)/$$p $(DESTDIR)$(pkgconfigdir)/$$p; \
++	  else if test -f $$p; then \
++	    echo " $(INSTALL_DATA) $$p $(DESTDIR)$(pkgconfigdir)/$$p"; \
++	    $(INSTALL_DATA) $$p $(DESTDIR)$(pkgconfigdir)/$$p; \
++	  fi; fi; \
++	done
++
++uninstall-pkgconfigDATA:
++	@$(NORMAL_UNINSTALL)
++	list='$(pkgconfig_DATA)'; for p in $$list; do \
++	  rm -f $(DESTDIR)$(pkgconfigdir)/$$p; \
++	done
++
+ distclean-hdr:
+ 	-rm -f config.h stamp-h1
+ libmad.list: $(top_builddir)/config.status $(srcdir)/libmad.list.in
+@@ -726,7 +750,7 @@
+
+ info-am:
+
+-install-data-am: install-includeHEADERS
++install-data-am: install-includeHEADERS install-pkgconfigDATA
+
+ install-exec-am: install-libLTLIBRARIES
+
+@@ -757,7 +781,7 @@
+ ps-am:
+
+ uninstall-am: uninstall-includeHEADERS uninstall-info-am \
+-	uninstall-libLTLIBRARIES
++	uninstall-libLTLIBRARIES install-pkgconfigDATA
+
+ uninstall-info: uninstall-info-recursive
+
+diff -ruN libmad-0.15.1b.orig/mad.pc.in libmad-0.15.1b/mad.pc.in
+--- libmad-0.15.1b.orig/mad.pc.in	1970-01-01 00:00:00.000000000 +0000
++++ libmad-0.15.1b/mad.pc.in	2005-08-25 12:08:04.000000000 +0000
+@@ -0,0 +1,10 @@
++prefix=@prefix@
++exec_prefix=@exec_prefix@
++libdir=@libdir@
++includedir=@includedir@
++
++Name: MAD
++Description: libmad - MPEG audio decoder library
++Version: @VERSION@
++Libs: -L${libdir} -lmad
++Cflags: -I${includedir}

--- a/ppc/libmad/pkg-config.patch
+++ b/ppc/libmad/pkg-config.patch
@@ -1,110 +1,25 @@
-; https://git.archlinux.org/svntogit/packages.git/tree/trunk/libmad.patch?h=packages/libmad
-diff -ruN libmad-0.15.1b.orig/Makefile.am libmad-0.15.1b/Makefile.am
---- libmad-0.15.1b.orig/Makefile.am	2004-02-17 02:02:03.000000000 +0000
-+++ libmad-0.15.1b/Makefile.am	2005-08-25 12:08:04.000000000 +0000
-@@ -33,9 +33,12 @@
- minimad_INCLUDES =
- minimad_LDADD =		libmad.la
-
--EXTRA_DIST =		mad.h.sed  \
-+EXTRA_DIST =		mad.h.sed mad.pc.in \
- 			CHANGES COPYRIGHT CREDITS README TODO VERSION
-
-+pkgconfigdir = $(libdir)/pkgconfig
-+pkgconfig_DATA= mad.pc
-+
- exported_headers =	version.h fixed.h bit.h timer.h stream.h frame.h  \
- 			synth.h decoder.h
-
-diff -ruN libmad-0.15.1b.orig/Makefile.in libmad-0.15.1b/Makefile.in
---- libmad-0.15.1b.orig/Makefile.in	2004-02-17 02:33:23.000000000 +0000
-+++ libmad-0.15.1b/Makefile.in	2005-08-25 12:09:34.000000000 +0000
-@@ -14,6 +14,8 @@
-
- @SET_MAKE@
-
-+pkgconfigdir = $(libdir)/pkgconfig
-+pkgconfig_DATA = mad.pc
-
- SOURCES = $(libmad_la_SOURCES) $(EXTRA_libmad_la_SOURCES) $(minimad_SOURCES)
-
-@@ -43,7 +45,7 @@
- 	$(srcdir)/Makefile.am $(srcdir)/Makefile.in \
- 	$(srcdir)/config.h.in $(srcdir)/libmad.list.in \
- 	$(top_srcdir)/configure COPYING INSTALL TODO config.guess \
--	config.sub depcomp install-sh ltmain.sh missing mkinstalldirs
-+	config.sub depcomp install-sh ltmain.sh missing mkinstalldirs mad.pc.in
- subdir = .
- ACLOCAL_M4 = $(top_srcdir)/aclocal.m4
- am__aclocal_m4_deps = $(top_srcdir)/configure.ac
-@@ -53,7 +55,7 @@
-  configure.lineno configure.status.lineno
- mkinstalldirs = $(SHELL) $(top_srcdir)/mkinstalldirs
- CONFIG_HEADER = config.h
--CONFIG_CLEAN_FILES = libmad.list
-+CONFIG_CLEAN_FILES = libmad.list mad.pc
- am__installdirs = $(DESTDIR)$(libdir) $(DESTDIR)$(includedir)
- libLTLIBRARIES_INSTALL = $(INSTALL)
- LTLIBRARIES = $(lib_LTLIBRARIES)
-@@ -218,7 +220,7 @@
- minimad_SOURCES = minimad.c
- minimad_INCLUDES =
- minimad_LDADD = libmad.la
--EXTRA_DIST = mad.h.sed  \
-+EXTRA_DIST = mad.h.sed  mad.pc.in \
- 			CHANGES COPYRIGHT CREDITS README TODO VERSION
-
- exported_headers = version.h fixed.h bit.h timer.h stream.h frame.h  \
-@@ -298,6 +300,28 @@
- 	rm -f stamp-h1
- 	touch $@
-
-+mad.pc: $(top_builddir)/config.status mad.pc.in
-+	cd $(top_builddir) && CONFIG_FILES=$@ CONFIG_HEADERS= $(SHELL) ./config.status
-+
-+install-pkgconfigDATA: $(pkgconfig_DATA)
-+	@$(NORMAL_INSTALL)
-+	$(mkinstalldirs) $(DESTDIR)$(pkgconfigdir)
-+	@list='$(pkgconfig_DATA)'; for p in $$list; do \
-+	  if test -f $(srcdir)/$$p; then \
-+	    echo " $(INSTALL_DATA) $(srcdir)/$$p $(DESTDIR)$(pkgconfigdir)/$$p"; \
-+	    $(INSTALL_DATA) $(srcdir)/$$p $(DESTDIR)$(pkgconfigdir)/$$p; \
-+	  else if test -f $$p; then \
-+	    echo " $(INSTALL_DATA) $$p $(DESTDIR)$(pkgconfigdir)/$$p"; \
-+	    $(INSTALL_DATA) $$p $(DESTDIR)$(pkgconfigdir)/$$p; \
-+	  fi; fi; \
-+	done
-+
-+uninstall-pkgconfigDATA:
-+	@$(NORMAL_UNINSTALL)
-+	list='$(pkgconfig_DATA)'; for p in $$list; do \
-+	  rm -f $(DESTDIR)$(pkgconfigdir)/$$p; \
-+	done
-+
- distclean-hdr:
- 	-rm -f config.h stamp-h1
- libmad.list: $(top_builddir)/config.status $(srcdir)/libmad.list.in
-@@ -726,7 +750,7 @@
-
- info-am:
-
--install-data-am: install-includeHEADERS
-+install-data-am: install-includeHEADERS install-pkgconfigDATA
-
- install-exec-am: install-libLTLIBRARIES
-
-@@ -757,7 +781,7 @@
- ps-am:
-
- uninstall-am: uninstall-includeHEADERS uninstall-info-am \
--	uninstall-libLTLIBRARIES
-+	uninstall-libLTLIBRARIES install-pkgconfigDATA
-
- uninstall-info: uninstall-info-recursive
-
-diff -ruN libmad-0.15.1b.orig/mad.pc.in libmad-0.15.1b/mad.pc.in
---- libmad-0.15.1b.orig/mad.pc.in	1970-01-01 00:00:00.000000000 +0000
-+++ libmad-0.15.1b/mad.pc.in	2005-08-25 12:08:04.000000000 +0000
+diff -Naur libmad-0.15.1b.orig/configure.ac libmad-0.15.1b/configure.ac
+--- libmad-0.15.1b.orig/configure.ac	2004-01-23 10:41:32.000000000 +0100
++++ libmad-0.15.1b/configure.ac	2015-10-12 05:51:12.514078692 +0200
+@@ -26,7 +26,7 @@
+ 
+ AC_CONFIG_SRCDIR([decoder.h])
+ 
+-AM_INIT_AUTOMAKE
++AM_INIT_AUTOMAKE([foreign])
+ 
+ AM_CONFIG_HEADER([config.h])
+ 
+@@ -429,5 +429,5 @@
+ dnl AC_SUBST(LTLIBOBJS)
+ 
+ AC_CONFIG_FILES([Makefile msvc++/Makefile  \
+-	libmad.list])
++	libmad.list mad.pc])
+ AC_OUTPUT
+diff -Naur libmad-0.15.1b.orig/mad.pc.in libmad-0.15.1b/mad.pc.in
+--- libmad-0.15.1b.orig/mad.pc.in	1970-01-01 01:00:00.000000000 +0100
++++ libmad-0.15.1b/mad.pc.in	2015-10-12 05:31:43.851805494 +0200
 @@ -0,0 +1,10 @@
 +prefix=@prefix@
 +exec_prefix=@exec_prefix@
@@ -115,4 +30,21 @@ diff -ruN libmad-0.15.1b.orig/mad.pc.in libmad-0.15.1b/mad.pc.in
 +Description: libmad - MPEG audio decoder library
 +Version: @VERSION@
 +Libs: -L${libdir} -lmad
-+Cflags: -I${includedir}
++Cflags:
+diff -Naur libmad-0.15.1b.orig/Makefile.am libmad-0.15.1b/Makefile.am
+--- libmad-0.15.1b.orig/Makefile.am	2004-02-17 03:02:03.000000000 +0100
++++ libmad-0.15.1b/Makefile.am	2015-10-12 05:31:43.831805227 +0200
+@@ -33,9 +33,12 @@
+ minimad_INCLUDES =	
+ minimad_LDADD =		libmad.la
+ 
+-EXTRA_DIST =		mad.h.sed  \
++EXTRA_DIST =		mad.h.sed mad.pc.in \
+ 			CHANGES COPYRIGHT CREDITS README TODO VERSION
+ 
++pkgconfigdir = $(libdir)/pkgconfig
++pkgconfig_DATA= mad.pc
++
+ exported_headers =	version.h fixed.h bit.h timer.h stream.h frame.h  \
+ 			synth.h decoder.h
+ 


### PR DESCRIPTION
PKGBUILD for libmad, from #57.
I don't really know much about libogc's use of libmad. It seems to me that it does basically the same thing we're doing here, just placing the libraries in `libogc/lib/{wii,cube}` rather than portlibs. With any luck, the linker should be able to sort itself out and pick one or the other (likely whatever ends up first on the search path). If libogc has wii-specific modifications or optimisations then something more complex may have to be done.
Thanks,
Ash