### PR TITLE
Add compiler flags to switch.cmake

### DIFF
--- a/pkgbuild-scripts/switch.cmake
+++ b/pkgbuild-scripts/switch.cmake
@@ -3,6 +3,9 @@ set(CMAKE_SYSTEM_PROCESSOR aarch64)
 
 set(SWITCH_LIBNX TRUE)
 
+set(CMAKE_C_FLAGS "-march=armv8-a -mtune=cortex-a57 -mtp=soft -fPIE")
+set(CMAKE_CXX_FLAGS "-march=armv8-a -mtune=cortex-a57 -mtp=soft -fPIE")
+
 set(CMAKE_EXE_LINKER_FLAGS_INIT "-march=armv8-a -mtune=cortex-a57 -mtp=soft -fPIE -ftls-model=local-exec -L/opt/devkitpro/portlibs/switch/lib -L/opt/devkitpro/libnx/lib -specs=/opt/devkitpro/libnx/switch.specs")
 set(CMAKE_MODULE_LINKER_FLAGS_INIT "${CMAKE_EXE_LINKER_FLAGS_INIT}")
 


### PR DESCRIPTION
These compiler flags need to be specified for any library you're porting, might as well put them in the toolchain file.