### PR TITLE
Add libjansson to ppc

### DIFF
--- a/ppc/jansson/.gitignore
+++ b/ppc/jansson/.gitignore
@@ -1,0 +1,1 @@
+ppc-jansson

--- a/ppc/jansson/PKGBUILD
+++ b/ppc/jansson/PKGBUILD
@@ -16,7 +16,6 @@ sha256sums=('5f8dec765048efac5d919aded51b26a32a05397ea207aa769ff6b53c7027d2c9')
 build() {
   cd jansson-$pkgver
 
-  source /opt/devkitpro/devkitppc.sh
   source /opt/devkitpro/ppcvars.sh
 
   ./configure --prefix="${PORTLIBS_PREFIX}" --host=powerpc-eabi \
@@ -27,7 +26,6 @@ build() {
 package() {
   cd jansson-$pkgver
 
-  source /opt/devkitpro/devkitppc.sh
   source /opt/devkitpro/ppcvars.sh
 
   make DESTDIR="$pkgdir" install

--- a/ppc/jansson/PKGBUILD
+++ b/ppc/jansson/PKGBUILD
@@ -1,0 +1,36 @@
+# Maintainer:  Dave Murphy <davem@devkitpro.org>
+# Contributor: Cpasjuste <cpasjuste@gmail.com>
+
+pkgname=3ds-jansson
+pkgver=2.11
+pkgrel=1
+pkgdesc='A C library for encoding, decoding and manipulating JSON data.'
+arch=('any')
+url='http://www.digip.org/jansson/'
+license=('custom')
+options=(!strip libtool staticlibs)
+makedepends=('devkitpro-pkgbuild-helpers')
+source=("http://www.digip.org/jansson/releases/jansson-$pkgver.tar.gz")
+sha256sums=('6e85f42dabe49a7831dbdd6d30dca8a966956b51a9a50ed534b82afc3fa5b2f4')
+
+build() {
+  cd jansson-$pkgver
+
+  source /opt/devkitpro/devkitarm.sh
+  source /opt/devkitpro/3dsvars.sh
+
+  ./configure --prefix="${PORTLIBS_PREFIX}" --host=arm-none-eabi \
+    --disable-shared --enable-static
+  make
+}
+
+package() {
+  cd jansson-$pkgver
+
+  source /opt/devkitpro/devkitarm.sh
+  source /opt/devkitpro/3dsvars.sh
+
+  make DESTDIR="$pkgdir" install
+  # license
+  install -Dm644 LICENSE "$pkgdir"${PORTLIBS_PREFIX}/licenses/$pkgname/LICENSE
+}

--- a/ppc/jansson/PKGBUILD
+++ b/ppc/jansson/PKGBUILD
@@ -12,6 +12,7 @@ options=(!strip libtool staticlibs)
 makedepends=('devkitpro-pkgbuild-helpers')
 source=("http://www.digip.org/jansson/releases/jansson-$pkgver.tar.gz")
 sha256sums=('5f8dec765048efac5d919aded51b26a32a05397ea207aa769ff6b53c7027d2c9')
+groups=('ppc-portlibs')
 
 build() {
   cd jansson-$pkgver

--- a/ppc/jansson/PKGBUILD
+++ b/ppc/jansson/PKGBUILD
@@ -2,7 +2,7 @@
 # Contributor: Cpasjuste <cpasjuste@gmail.com>
 
 pkgname=ppc-jansson
-pkgver=2.11
+pkgver=2.12
 pkgrel=1
 pkgdesc='A C library for encoding, decoding and manipulating JSON data.'
 arch=('any')
@@ -11,7 +11,7 @@ license=('custom')
 options=(!strip libtool staticlibs)
 makedepends=('devkitpro-pkgbuild-helpers')
 source=("http://www.digip.org/jansson/releases/jansson-$pkgver.tar.gz")
-sha256sums=('6e85f42dabe49a7831dbdd6d30dca8a966956b51a9a50ed534b82afc3fa5b2f4')
+sha256sums=('5f8dec765048efac5d919aded51b26a32a05397ea207aa769ff6b53c7027d2c9')
 
 build() {
   cd jansson-$pkgver

--- a/ppc/jansson/PKGBUILD
+++ b/ppc/jansson/PKGBUILD
@@ -1,5 +1,5 @@
 # Maintainer:  Dave Murphy <davem@devkitpro.org>
-# Contributor: Cpasjuste <cpasjuste@gmail.com>
+# Contributor: Crayon <crayon1@rocketmail.com>
 
 pkgname=ppc-jansson
 pkgver=2.12

--- a/ppc/jansson/PKGBUILD
+++ b/ppc/jansson/PKGBUILD
@@ -1,7 +1,7 @@
 # Maintainer:  Dave Murphy <davem@devkitpro.org>
 # Contributor: Cpasjuste <cpasjuste@gmail.com>
 
-pkgname=3ds-jansson
+pkgname=ppc-jansson
 pkgver=2.11
 pkgrel=1
 pkgdesc='A C library for encoding, decoding and manipulating JSON data.'
@@ -16,10 +16,10 @@ sha256sums=('6e85f42dabe49a7831dbdd6d30dca8a966956b51a9a50ed534b82afc3fa5b2f4')
 build() {
   cd jansson-$pkgver
 
-  source /opt/devkitpro/devkitarm.sh
-  source /opt/devkitpro/3dsvars.sh
+  source /opt/devkitpro/devkitppc.sh
+  source /opt/devkitpro/ppcvars.sh
 
-  ./configure --prefix="${PORTLIBS_PREFIX}" --host=arm-none-eabi \
+  ./configure --prefix="${PORTLIBS_PREFIX}" --host=powerpc-eabi \
     --disable-shared --enable-static
   make
 }
@@ -27,8 +27,8 @@ build() {
 package() {
   cd jansson-$pkgver
 
-  source /opt/devkitpro/devkitarm.sh
-  source /opt/devkitpro/3dsvars.sh
+  source /opt/devkitpro/devkitppc.sh
+  source /opt/devkitpro/ppcvars.sh
 
   make DESTDIR="$pkgdir" install
   # license


### PR DESCRIPTION
The _PKGBUILD_ file is based on the 3DS version but this one uses ppc and libjansson version 2.12. libjansson v2.11 is also used for the Switch.

I have kept 3 commits because I think it might be easier to review the changes this way. If accepted I propose to Squash all commits into one before merging.