### PR TITLE
Add 3ds-libdl.

### DIFF
--- a/3ds/libdl/PKGBUILD
+++ b/3ds/libdl/PKGBUILD
@@ -1,0 +1,27 @@
+# Contributor: Teddy Astie <TSnake@Outlook.fr>
+# Maintainer:
+
+pkgname=3ds-libdl
+pkgver=1.0.0
+pkgrel=1
+pkgdesc='Extensible libdl library for projects that needs it.'
+arch=('any')
+options=(!strip)
+makedepends=('devkitpro-pkgbuild-helpers')
+source=('dlfcn.c' 'dlfcn.h')
+sha256sums=('9c84be0ef4365a3b2ed3948426ecfbdf8116611d63d5ec42d4af8a551c20ef72' '37c16bc645be27cad69904a53973a8862c37890f7327f6b26998794c62527336')
+groups=('3ds-portlibs')
+
+build() {
+  source /opt/devkitpro/3dsvars.sh
+  
+  arm-none-eabi-gcc $CFLAGS -c -o dlfcn.o dlfcn.c
+  arm-none-eabi-ar rcu libdl.a dlfcn.o
+}
+
+package() {
+  source /opt/devkitpro/3dsvars.sh
+  mkdir -p $pkgdir$PORTLIBS_PREFIX/lib/ $pkgdir$PORTLIBS_PREFIX/include
+  cp libdl.a $pkgdir$PORTLIBS_PREFIX/lib/
+  cp dlfcn.h $pkgdir$PORTLIBS_PREFIX/include/
+}

--- a/3ds/libdl/dlfcn.c
+++ b/3ds/libdl/dlfcn.c
@@ -1,0 +1,36 @@
+#include "dlfcn.h"
+
+#include <stddef.h>
+
+static dl_open open = NULL;
+static dl_error error = NULL;
+static dl_sym sym = NULL;
+static dl_close close = NULL;
+
+void dl_setfn(dl_open new_open, dl_error new_error, dl_sym new_sym, dl_close new_close)
+{
+  open = new_open;
+  error = new_error;
+  sym = new_sym;
+  close = new_close;
+}
+
+void *dlopen(const char *module, int flag)
+{
+  return open ? (*open)(module, flag) : NULL;
+}
+
+char *dlerror(void)
+{
+  return error ? (*error)() : "";
+}
+
+void *dlsym(void *handle, const char *name)
+{
+  return sym ? (*sym)(handle, name) : NULL;
+}
+
+int dlclose(void *handle)
+{
+  return close ? (*close)(handle) : 0;
+}

--- a/3ds/libdl/dlfcn.h
+++ b/3ds/libdl/dlfcn.h
@@ -1,0 +1,25 @@
+#ifndef __DLFCN_H__
+#define __DLFCN_H__
+
+#define RTLD_LAZY 0
+#define RTLD_NOW 1
+#define RTLD_GLOBAL 2
+#define RTLD_LOCAL 3
+
+/* Defines a dlfcn.h compatible API. */
+void *dlopen(const char *module, int flag);
+char *dlerror(void);
+void *dlsym(void *handle, const char *name);
+int dlclose(void *handle);
+
+/* Add a custom API to change builtin functions with user-provided ones.
+ * This is useful to expand dlfcn to something working when needed (e.g LuaJIT FFI).
+ */
+typedef void *(*dl_open)(const char *, int);
+typedef char *(*dl_error)(void);
+typedef void *(*dl_sym)(void *, const char *);
+typedef int (*dl_close)(void *);
+
+void dl_setfn(dl_open open, dl_error error, dl_sym sym, dl_close close);
+
+#endif /* __DLFCN_H__ */


### PR DESCRIPTION
As possibly needed with #85. This is a _extendable_ stub implementation of libdl.

It implements a "fake" libdl that can be needed for some libraries (like LuaJIT FFI).
You can (if needed) change the functions bound to the stub library using dl_setfn().