### PR TITLE
Add switch-libgd

### DIFF
--- a/switch/libgd/PKGBUILD
+++ b/switch/libgd/PKGBUILD
@@ -1,0 +1,43 @@
+# Contributor: Steven Mattera <me@stevenmattera.com>
+
+pkgname=switch-libgd
+pkgver=2.2.5
+pkgrel=2
+pkgdesc="Library for the dynamic creation of images"
+url="https://libgd.github.io"
+license=("custom")
+arch=("any")
+depends=("switch-freetype" "switch-bzip2" "switch-libpng" "switch-zlib" "switch-libjpeg-turbo" "switch-libwebp")
+makedepends=("switch-pkg-config" "devkitpro-pkgbuild-helpers")
+options=("!buildflags" "staticlibs" "libtool" "!strip")
+source=("https://github.com/libgd/libgd/releases/download/gd-$pkgver/libgd-$pkgver.tar.xz"
+        "libgd-2.2.5-nosyslog.patch")
+sha256sums=("8c302ccbf467faec732f0741a859eef4ecae22fea2d2ab87467be940842bde51"
+            "549027858ef0d2d6dec42232bcc2d66a5966d9f66bfc30518dfd026090a3d2d5")
+groups=('switch-portlibs')
+
+prepare() {
+    patch libgd-$pkgver/src/gd_errors.h < libgd-2.2.5-nosyslog.patch
+}
+
+build() {
+    cd libgd-$pkgver
+
+    source /opt/devkitpro/switchvars.sh
+
+   ./configure --prefix="${PORTLIBS_PREFIX}" --host=aarch64-none-elf --disable-shared --enable-static
+
+    make
+}
+
+package() {
+    cd libgd-$pkgver
+
+    source /opt/devkitpro/switchvars.sh
+
+    make DESTDIR="$pkgdir" install
+    install -Dm644 COPYING "$pkgdir/$PORTLIBS_PREFIX/licenses/$pkgname/COPYING"
+
+    # These binaries all end up for aarch64, so we shouldn't keep them
+    rm -rf "$pkgdir/$PORTLIBS_PREFIX/bin"
+}

--- a/switch/libgd/PKGBUILD
+++ b/switch/libgd/PKGBUILD
@@ -1,4 +1,4 @@
-# Contributor: Steven Mattera <me@stevenmattera.com>
+# Contributor: Nichole Mattera <me@nicholemattera.com>
 
 pkgname=switch-libgd
 pkgver=2.2.5

--- a/switch/libgd/libgd-2.2.5-nosyslog.patch
+++ b/switch/libgd/libgd-2.2.5-nosyslog.patch
@@ -1,0 +1,6 @@
+4,6d3
+< #ifndef _WIN32
+< # include <syslog.h>
+< #else
+24d20
+< #endif


### PR DESCRIPTION
Someone needed a library to resize images on the Switch. Saw libGD was available for PPC made a few simple modifications for it to compile for the Switch.