### PR TITLE
switch: add libsmb2

### DIFF
--- a/switch/libsmb2/.gitignore
+++ b/switch/libsmb2/.gitignore
@@ -1,0 +1,2 @@
+*.tgz
+switch-libsmb2

--- a/switch/libsmb2/PKGBUILD
+++ b/switch/libsmb2/PKGBUILD
@@ -24,6 +24,7 @@ prepare() {
   patch -Np1 -i "$srcdir/../libsmb2-91d6c8a-define_getlogin_r.patch"
   patch -Np1 -i "$srcdir/../libsmb2-91d6c8a-define_net_readv_writev.patch"
   patch -Np1 -i "$srcdir/../libsmb2-91d6c8a-fix_portable_endian_include.patch"
+  patch -Np1 -i "$srcdir/../libsmb2-91d6c8a-fix_getaddrinfo_hints.patch"
   patch -Np1 -i "$srcdir/../libsmb2-91d6c8a-fix_makefile_libnx_include.patch"
 }
 

--- a/switch/libsmb2/PKGBUILD
+++ b/switch/libsmb2/PKGBUILD
@@ -1,24 +1,32 @@
 # Maintainer: Rhys Koedijk <rhys@koedijk.co.nz>
 
 pkgname=switch-libsmb2
-pkgver=3.0.0
-pkgrel=2
+pkgver=r285.91d6c8a
+pkgrel=1
 pkgdesc='SMB2/3 userspace client'
 arch=('any')
 url='https://github.com/sahlberg/libsmb2'
 license=('(L)GPL')
 options=(!strip libtool staticlibs)
-source=("https://github.com/sahlberg/libsmb2/archive/v${pkgver}.tar.gz")
-sha256sums=('36d10d1628ad34d56646bf9e7005a8abe8ce6b67ba3a949d537ae3e5f08f701f')
-makedepends=('switch-pkg-config' 'devkitpro-pkgbuild-helpers')
+source=(${pkgname}::"git+https://github.com/sahlberg/libsmb2.git#commit=91d6c8a44b6f6adaa879cc556cf96ff6077bbb4f")
+sha256sums=('SKIP')
+makedepends=('git' 'switch-pkg-config' 'devkitpro-pkgbuild-helpers')
 groups=('switch-portlibs')
 
+pkgver() {
+  cd "$srcdir/${pkgname}"
+  printf 'r%s.%s' "$(git rev-list --count HEAD)" "$(git rev-parse --short HEAD)"
+}
+
 prepare() {
-  cd .
+  cd ${pkgname}
+  patch -Np1 -i "$srcdir/../libsmb2-91d6c8a-define_endian_macros.patch"
+  patch -Np1 -i "$srcdir/../libsmb2-91d6c8a-define_getlogin_r.patch"
+  patch -Np1 -i "$srcdir/../libsmb2-91d6c8a-fix_portable_endian_include.patch"
 }
 
 build() {
-  cd libsmb2-$pkgver
+  cd ${pkgname}
 
   source /opt/devkitpro/switchvars.sh
 
@@ -31,13 +39,14 @@ build() {
   ./configure --prefix="${PORTLIBS_PREFIX}" --host=aarch64-none-elf \
     --disable-shared --enable-static --without-libkrb5
 
-  #cp config.h /lib
-
   make
 }
 
 package() {
-  cd libsmb2-$pkgver
-
+  cd ${pkgname}
+  
   make DESTDIR="$pkgdir" install
+  
+  install -Dm644 LICENCE "$pkgdir"/opt/devkitpro/portlibs/switch/licenses/$pkgname/LICENCE-LGPL-2.1.txt
+  rm -r "$pkgdir"/opt/devkitpro/portlibs/switch/share
 }

--- a/switch/libsmb2/PKGBUILD
+++ b/switch/libsmb2/PKGBUILD
@@ -1,14 +1,14 @@
 # Maintainer: Rhys Koedijk <rhys@koedijk.co.nz>
 
 pkgname=switch-libsmb2
-pkgver=r285.91d6c8a
+pkgver=r307.aef1888
 pkgrel=1
 pkgdesc='SMB2/3 userspace client'
 arch=('any')
 url='https://github.com/sahlberg/libsmb2'
 license=('(L)GPL')
 options=(!strip libtool staticlibs)
-source=(${pkgname}::"git+https://github.com/sahlberg/libsmb2.git#commit=91d6c8a44b6f6adaa879cc556cf96ff6077bbb4f")
+source=(${pkgname}::"git+https://github.com/sahlberg/libsmb2.git#commit=aef1888f0f04bb41a38262d3388d7b673e48a1ed")
 sha256sums=('SKIP')
 makedepends=('git' 'switch-pkg-config' 'devkitpro-pkgbuild-helpers')
 groups=('switch-portlibs')
@@ -22,7 +22,9 @@ prepare() {
   cd ${pkgname}
   patch -Np1 -i "$srcdir/../libsmb2-91d6c8a-define_endian_macros.patch"
   patch -Np1 -i "$srcdir/../libsmb2-91d6c8a-define_getlogin_r.patch"
+  patch -Np1 -i "$srcdir/../libsmb2-91d6c8a-define_net_readv_writev.patch"
   patch -Np1 -i "$srcdir/../libsmb2-91d6c8a-fix_portable_endian_include.patch"
+  patch -Np1 -i "$srcdir/../libsmb2-91d6c8a-fix_makefile_libnx_include.patch"
 }
 
 build() {
@@ -47,6 +49,5 @@ package() {
   
   make DESTDIR="$pkgdir" install
   
-  install -Dm644 LICENCE "$pkgdir"/opt/devkitpro/portlibs/switch/licenses/$pkgname/LICENCE-LGPL-2.1.txt
-  rm -r "$pkgdir"/opt/devkitpro/portlibs/switch/share
+  install -Dm644 LICENCE-LGPL-2.1.txt "$pkgdir"/opt/devkitpro/portlibs/switch/licenses/$pkgname/LICENCE
 }

--- a/switch/libsmb2/PKGBUILD
+++ b/switch/libsmb2/PKGBUILD
@@ -1,0 +1,43 @@
+# Maintainer: Rhys Koedijk <rhys@koedijk.co.nz>
+
+pkgname=switch-libsmb2
+pkgver=3.0.0
+pkgrel=2
+pkgdesc='SMB2/3 userspace client'
+arch=('any')
+url='https://github.com/sahlberg/libsmb2'
+license=('(L)GPL')
+options=(!strip libtool staticlibs)
+source=("https://github.com/sahlberg/libsmb2/archive/v${pkgver}.tar.gz")
+sha256sums=('36d10d1628ad34d56646bf9e7005a8abe8ce6b67ba3a949d537ae3e5f08f701f')
+makedepends=('switch-pkg-config' 'devkitpro-pkgbuild-helpers')
+groups=('switch-portlibs')
+
+prepare() {
+  cd .
+}
+
+build() {
+  cd libsmb2-$pkgver
+
+  source /opt/devkitpro/switchvars.sh
+
+  libtoolize
+  aclocal
+  autoheader
+  automake --add-missing
+  autoconf
+
+  ./configure --prefix="${PORTLIBS_PREFIX}" --host=aarch64-none-elf \
+    --disable-shared --enable-static --without-libkrb5
+
+  #cp config.h /lib
+
+  make
+}
+
+package() {
+  cd libsmb2-$pkgver
+
+  make DESTDIR="$pkgdir" install
+}

--- a/switch/libsmb2/libsmb2-91d6c8a-define_endian_macros.patch
+++ b/switch/libsmb2/libsmb2-91d6c8a-define_endian_macros.patch
@@ -1,0 +1,30 @@
+diff --git a/include/portable-endian.h b/include/portable-endian.h
+index e0730b2..17e1b3f 100644
+--- a/include/portable-endian.h
++++ b/include/portable-endian.h
+@@ -110,6 +110,25 @@
+ #     error platform not supported
+ #   endif
+ 
++#elif defined(__SWITCH__)
++
++#  include <machine/endian.h>
++
++#  define htobe16(x) __bswap16(x)
++#  define htole16(x) (x)
++#  define be16toh(x) __bswap16(x)
++#  define le16toh(x) (x)
++
++#  define htobe32(x) __bswap32(x)
++#  define htole32(x) (x)
++#  define be32toh(x) __bswap32(x)
++#  define le32toh(x) (x)
++
++#  define htobe64(x) __bswap64(x)
++#  define htole64(x) (x)
++#  define be64toh(x) __bswap64(x)
++#  define le64toh(x) (x)
++
+ #else
+ #  error platform not supported
+ #endif

--- a/switch/libsmb2/libsmb2-91d6c8a-define_getlogin_r.patch
+++ b/switch/libsmb2/libsmb2-91d6c8a-define_getlogin_r.patch
@@ -1,0 +1,16 @@
+diff --git a/lib/init.c b/lib/init.c
+index aeb1982..f349cd4 100644
+--- a/lib/init.c
++++ b/lib/init.c
+@@ -74,6 +74,11 @@
+ #endif
+ #endif // __ANDROID__
+ 
++#ifdef __SWITCH__
++#include <errno.h>
++#define getlogin_r(a,b) ENXIO
++#endif // __SWITCH__
++
+ static int
+ smb2_parse_args(struct smb2_context *smb2, const char *args)
+ {

--- a/switch/libsmb2/libsmb2-91d6c8a-define_net_readv_writev.patch
+++ b/switch/libsmb2/libsmb2-91d6c8a-define_net_readv_writev.patch
@@ -1,0 +1,57 @@
+diff --git a/lib/socket.c b/lib/socket.c
+index 978f06d..a7fde76 100644
+--- a/lib/socket.c
++++ b/lib/socket.c
+@@ -80,6 +80,52 @@
+ 
+ #define MAX_URL_SIZE 256
+ 
++#ifdef __SWITCH__
++
++#include <netdb.h>
++#include <netinet/tcp.h>
++#include <netinet/in.h>
++#include <poll.h>
++
++ssize_t writev(int fd, const struct iovec *iov, int iovcnt)
++{
++  int total = 0;
++  for (int i = 0; i < iovcnt; i++) {
++    int left = iov[i].iov_len;
++    while (left > 0) {
++      int count = write(fd, iov[i].iov_base, left);
++      if (count == -1) {
++        return -1;
++      }
++      total += count;
++      left -= count;
++    }
++  }
++  return total;
++}
++
++ssize_t readv(int fd, const struct iovec *iov, int iovcnt)
++{
++  ssize_t total = 0;
++  for (int i = 0; i < iovcnt; i++) {
++    int left = iov[i].iov_len;
++    while (left > 0) {
++      int count = read(fd, iov[i].iov_base, left);
++      if (count == -1) {
++        return -1;
++      }
++      if (count == 0) {
++        return total;
++      }
++      total += count;
++      left -= count;
++    }
++  }
++  return total;
++}
++
++#endif
++
+ static int
+ smb2_get_credit_charge(struct smb2_context *smb2, struct smb2_pdu *pdu)
+ {

--- a/switch/libsmb2/libsmb2-91d6c8a-fix_getaddrinfo_hints.patch
+++ b/switch/libsmb2/libsmb2-91d6c8a-fix_getaddrinfo_hints.patch
@@ -1,0 +1,20 @@
+diff --git a/lib/socket.c b/lib/socket.c
+index 978f06d..156fad5 100644
+--- a/lib/socket.c
++++ b/lib/socket.c
+@@ -701,9 +747,14 @@ smb2_connect_async(struct smb2_context *smb2, const char *server,
+         } else {
+                 port = "445";
+         }
++        
++        struct addrinfo hints;
++        memset(&hints, 0, sizeof hints);
++        hints.ai_family = AF_INET; // AF_INET or AF_INET6 to force version
++        hints.ai_socktype = SOCK_STREAM;
+ 
+         /* is it a hostname ? */
+-        if (getaddrinfo(host, port, NULL, &ai) != 0) {
++        if (getaddrinfo(host, port, &hints, &ai) != 0) {
+                 free(addr);
+                 smb2_set_error(smb2, "Invalid address:%s  "
+                                "Can not resolv into IPv4/v6.", server);

--- a/switch/libsmb2/libsmb2-91d6c8a-fix_makefile_libnx_include.patch
+++ b/switch/libsmb2/libsmb2-91d6c8a-fix_makefile_libnx_include.patch
@@ -1,0 +1,12 @@
+diff --git a/lib/Makefile.am b/lib/Makefile.am
+index 72a86ec..fe133eb 100644
+--- a/lib/Makefile.am
++++ b/lib/Makefile.am
+@@ -4,6 +4,7 @@ lib_LTLIBRARIES = libsmb2.la
+ 
+ libsmb2_la_CPPFLAGS = -I$(abs_top_srcdir)/include \
+ 		      -I$(abs_top_srcdir)/include/smb2 \
++			  -I$(DEVKITPRO)/libnx/include \
+ 		      "-D_U_=__attribute__((unused))"
+ 
+ libsmb2_la_SOURCES = \

--- a/switch/libsmb2/libsmb2-91d6c8a-fix_portable_endian_include.patch
+++ b/switch/libsmb2/libsmb2-91d6c8a-fix_portable_endian_include.patch
@@ -1,0 +1,12 @@
+diff --git a/lib/aes128ccm.c b/lib/aes128ccm.c
+index 10bd11d..bcc492d 100644
+--- a/lib/aes128ccm.c
++++ b/lib/aes128ccm.c
+@@ -21,6 +21,7 @@
+ #include <string.h>
+ 
+ #include "aes.h"
++#include "portable-endian.h"
+ 
+ static void aes_ccm_generate_b0(unsigned char *nonce, int nlen,
+                                 int alen, int plen, int mlen,


### PR DESCRIPTION
Unstable port of `libsmb2` (built against HEAD). 
Not sure if this should wait until the next upstream release, but it is working fine for my needs as-is so I thought I'd share it. I would appreciate any feedback on the comments, not sure if they can be done in a better way.

Kerberos auth is not supported, but simple auth (username/password) works well.
Share enumeration/discovery works well too.

Basic usage:
````csharp
socketInitializeDefault();

ctx = smb2_init_context();
url = smb2_parse_url(ctx, "smb://[<domain;][<username>@]<host>[:<port>]/")
smb2_set_security_mode(ctx, SMB2_NEGOTIATE_SIGNING_ENABLED);
smb2_set_user(ctx, url->user); // if auth is required
smb2_set_password(ctx, "PASSWORD"); // if auth is required
smb2_connect_share(ctx, url->server, "SHARE_NAME", NULL);

// do the thing...

smb2_disconnect_share(ctx);
smb2_destroy_url(url);
smb2_destroy_context(ctx);

socketExit();
````

Better examples here:
https://github.com/sahlberg/libsmb2/tree/master/examples