### PR TITLE
add MBEDTLS_CMAC_C

### DIFF
--- a/switch/mbedtls/PKGBUILD
+++ b/switch/mbedtls/PKGBUILD
@@ -25,6 +25,7 @@ build() {
 
   ./scripts/config.pl set MBEDTLS_ENTROPY_HARDWARE_ALT
   ./scripts/config.pl set MBEDTLS_NO_PLATFORM_ENTROPY
+  ./scripts/config.pl set MBEDTLS_CMAC_C
 
   ./scripts/config.pl unset MBEDTLS_TIMING_C
   ./scripts/config.pl unset MBEDTLS_SELF_TEST


### PR DESCRIPTION
This is needed for running hactool on the switch so I'd appreciate it getting merged.