### PR TITLE
3ds: add luajit

### DIFF
--- a/3ds/luajit/PKGBUILD
+++ b/3ds/luajit/PKGBUILD
@@ -9,16 +9,16 @@ url='http://luajit.org/'
 license=('MIT')
 options=(!strip)
 makedepends=('3ds-pkg-config' 'devkitpro-pkgbuild-helpers')
-source=("https://luajit.org/download/LuaJIT-$pkgver.tar.gz" "luajit.pc.patch")
-sha256sums=('874b1f8297c697821f561f9b73b57ffd419ed8f4278c82e05b48806d30c1e979'
-            'b993f4bfb7dab888f909f6973996783d481d4cf767eca1d8a68df45202fcab9e')
+source=("https://luajit.org/download/LuaJIT-$pkgver.tar.gz")
+sha256sums=('874b1f8297c697821f561f9b73b57ffd419ed8f4278c82e05b48806d30c1e979')
 groups=('3ds-portlibs')
 
 build() {
   cd LuaJIT-$pkgver
   source /opt/devkitpro/3dsvars.sh
 
-  patch etc/luajit.pc ../luajit.pc.patch
+  # Remove link options. 
+  sed -i -e "s| *-Wl,-E||g" -e "s|-ldl||g" etc/luajit.pc
 
   touch src/luajit src/jit/vmdef.lua
   make BUILDMODE=static \

--- a/3ds/luajit/PKGBUILD
+++ b/3ds/luajit/PKGBUILD
@@ -1,0 +1,44 @@
+# Contributor: Teddy Astie <TSnake@Outlook.fr>
+
+pkgname=3ds-luajit
+pkgver=2.0.5
+pkgrel=1
+pkgdesc='Just-in-time compiler and drop-in replacement for Lua 5.1 (for Nintendo 3DS homebrew development)'
+arch=('any')
+url='http://luajit.org/'
+license=('MIT')
+options=(!strip)
+makedepends=('3ds-pkg-config' 'devkitpro-pkgbuild-helpers' '3ds-libdl')
+source=("https://luajit.org/download/LuaJIT-$pkgver.tar.gz")
+sha256sums=('874b1f8297c697821f561f9b73b57ffd419ed8f4278c82e05b48806d30c1e979')
+groups=('3ds-portlibs')
+
+build() {
+  cd LuaJIT-$pkgver
+  source /opt/devkitpro/3dsvars.sh
+
+  # We need to "patch" lj_arch.h to assume the existence of libdl on a non-POSIX platform.
+  # This looks weird, but in the pkg-config file, libdl is linked regardless if it is
+  # actually used or not. This patch harmonize the implementation and allow to use the full
+  # LuaJIT FFI API (based on libdl).
+  #
+  # Redefine LJ_TARGET_DLOPEN with 1 (instead of LJ_TARGET_POSIX)
+  echo -e "#undef LJ_TARGET_DLOPEN\n#define LJ_TARGET_DLOPEN 1\n" >> src/lj_arch.h
+
+  echo $CFLAGS
+  touch src/luajit src/jit/vmdef.lua
+  make TARGET_SYS=OTHER TARGET_FLAGS="$CFLAGS -I$PORTLIBS_PREFIX/include" TARGET_T=libluajit.a BUILDMODE=static \
+    HOST_CC="gcc -m32"  XCFLAGS="-DLUAJIT_USE_SYSMALLOC" CFLAGS="" LDFLAGS="" LIBS="" HOST_CFLAGS="" HOST_LIBS="" HOST_LDFLAGS="" \
+    CROSS=arm-none-eabi- PREFIX=${PORTLIBS_PREFIX} DESTDIR=$pkgdir amalg
+}
+
+package() {
+  cd LuaJIT-$pkgver
+  source /opt/devkitpro/3dsvars.sh
+
+  make PREFIX=$PORTLIBS_PREFIX DESTDIR=$pkgdir INSTALL_DEP= install
+
+  cd $pkgdir$PORTLIBS_PREFIX
+
+  rm -rf bin share lib/lua
+}

--- a/3ds/luajit/PKGBUILD
+++ b/3ds/luajit/PKGBUILD
@@ -8,28 +8,24 @@ arch=('any')
 url='http://luajit.org/'
 license=('MIT')
 options=(!strip)
-makedepends=('3ds-pkg-config' 'devkitpro-pkgbuild-helpers' '3ds-libdl')
-source=("https://luajit.org/download/LuaJIT-$pkgver.tar.gz")
-sha256sums=('874b1f8297c697821f561f9b73b57ffd419ed8f4278c82e05b48806d30c1e979')
+makedepends=('3ds-pkg-config' 'devkitpro-pkgbuild-helpers')
+source=("https://luajit.org/download/LuaJIT-$pkgver.tar.gz" "luajit.pc.patch")
+sha256sums=('874b1f8297c697821f561f9b73b57ffd419ed8f4278c82e05b48806d30c1e979'
+            'b993f4bfb7dab888f909f6973996783d481d4cf767eca1d8a68df45202fcab9e')
 groups=('3ds-portlibs')
 
 build() {
   cd LuaJIT-$pkgver
   source /opt/devkitpro/3dsvars.sh
 
-  # We need to "patch" lj_arch.h to assume the existence of libdl on a non-POSIX platform.
-  # This looks weird, but in the pkg-config file, libdl is linked regardless if it is
-  # actually used or not. This patch harmonize the implementation and allow to use the full
-  # LuaJIT FFI API (based on libdl).
-  #
-  # Redefine LJ_TARGET_DLOPEN with 1 (instead of LJ_TARGET_POSIX)
-  echo -e "#undef LJ_TARGET_DLOPEN\n#define LJ_TARGET_DLOPEN 1\n" >> src/lj_arch.h
+  patch etc/luajit.pc ../luajit.pc.patch
 
-  echo $CFLAGS
   touch src/luajit src/jit/vmdef.lua
-  make TARGET_SYS=OTHER TARGET_FLAGS="$CFLAGS -I$PORTLIBS_PREFIX/include" TARGET_T=libluajit.a BUILDMODE=static \
-    HOST_CC="gcc -m32"  XCFLAGS="-DLUAJIT_USE_SYSMALLOC" CFLAGS="" LDFLAGS="" LIBS="" HOST_CFLAGS="" HOST_LIBS="" HOST_LDFLAGS="" \
-    CROSS=arm-none-eabi- PREFIX=${PORTLIBS_PREFIX} DESTDIR=$pkgdir amalg
+  make BUILDMODE=static \
+    TARGET_FLAGS="$CFLAGS -I$PORTLIBS_PREFIX/include" TARGET_T=libluajit.a \
+    CFLAGS="" LDFLAGS="" LIBS="" HOST_CFLAGS="" HOST_LIBS="" HOST_LDFLAGS="" \
+    HOST_CC="gcc -m32" XCFLAGS="-DLUAJIT_USE_SYSMALLOC" CROSS=${TOOL_PREFIX} \
+    amalg
 }
 
 package() {
@@ -39,6 +35,5 @@ package() {
   make PREFIX=$PORTLIBS_PREFIX DESTDIR=$pkgdir INSTALL_DEP= install
 
   cd $pkgdir$PORTLIBS_PREFIX
-
   rm -rf bin share lib/lua
 }

--- a/3ds/luajit/luajit.pc.patch
+++ b/3ds/luajit/luajit.pc.patch
@@ -1,0 +1,9 @@
+--- etc/luajit.pc	2020-04-14 15:22:35.324534900 +0200
++++ etc/luajit-patched.pc	2020-04-14 15:22:39.540172300 +0200
+@@ -21,5 +21,5 @@
+ Version: ${version}
+ Requires:
+ Libs: -L${libdir} -l${libname}
+-Libs.private: -Wl,-E -lm -ldl
++Libs.private: -Wl,-E -lm
+ Cflags: -I${includedir}

--- a/3ds/luajit/luajit.pc.patch
+++ b/3ds/luajit/luajit.pc.patch
@@ -1,9 +1,0 @@
---- etc/luajit.pc	2020-04-14 15:22:35.324534900 +0200
-+++ etc/luajit-patched.pc	2020-04-14 15:22:39.540172300 +0200
-@@ -21,5 +21,5 @@
- Version: ${version}
- Requires:
- Libs: -L${libdir} -l${libname}
--Libs.private: -Wl,-E -lm -ldl
-+Libs.private: -Wl,-E -lm
- Cflags: -I${includedir}


### PR DESCRIPTION
This is a cleaned up version of https://github.com/devkitPro/pacman-packages/pull/85 that got too complicated.

I also added few notable changes from original pull-request : 
 - there is no longer need of libdl (that required a slight source code hack while building) so I added a luajit.pc patch to remove the link to libdl (see luajit.pc.patch), LuaJIT will use default "console" behavior and throw and error when attempting to use ffi.load and few other functions (which is the expected behavior).
    - this will prevent potential breaking if some change in the source code affect this hack
    - as it is recognized as a "console" platform, libdl is not used

notes :
JIT is working with various optimization (ARMv6, VFPv2, and standard JIT optimizations) but assumes that XN-bit is not set on malloc-ed memory (this has to be verified).

In case of issues with JIT we can still set `-DLUAJIT_DISABLE_JIT` to disable JIT and still have FFI plus a significant performance boost compared to original Lua 5.1. Note that this setting is required for a LuaJIT Switch port.

Used in [LovePotion LuaJIT port](https://github.com/TSnake41/LovePotion/tree/luajit-new)