### PR TITLE
Update switch-mbedtls to 2.16.6.

### DIFF
--- a/switch/mbedtls/PKGBUILD
+++ b/switch/mbedtls/PKGBUILD
@@ -1,5 +1,5 @@
 pkgname=switch-mbedtls
-pkgver=2.16.0
+pkgver=2.16.6
 pkgrel=1
 pkgdesc='An open source, portable, easy to use, readable and flexible SSL library'
 arch=('any')
@@ -14,7 +14,7 @@ source=(
 )
 groups=('switch-portlibs')
 sha256sums=(
- 'e3dab56e9093c790b7d5e0f7eb19451010fe680649d25cf1dcca9d5441669ae2'
+ '66455e23a6190a30142cdc1113f7418158839331a9d8e6b0778631d077281770'
  'c0cf5e262788144fb4c4a163334f7c55c8b4c2b93a9fc780e3f7cdf5d236aca0'
 )
 


### PR DESCRIPTION
NOTE: I didn't confirm this actually work, but it probably does. At least the build was successful.
