### PR TITLE
pkgbuild-scripts: Add wiivars.sh and wiiuvars.sh to the list of devkitPPC files to install

### DIFF
--- a/pkgbuild-scripts/PKGBUILD
+++ b/pkgbuild-scripts/PKGBUILD
@@ -54,7 +54,7 @@ package() {
   install -d "$pkgdir"/opt/devkitpro/cmake
   install -Dm644 devkitarm.sh devkitarm.cmake 3ds.cmake 3dsvars.sh ndsvars.sh "$pkgdir"/opt/devkitpro
   install -Dm644 devkita64.sh devkita64.cmake switch.cmake switchvars.sh "$pkgdir"/opt/devkitpro
-  install -Dm644 devkitppc.sh devkitppc.cmake gamecube.cmake wii.cmake ppcvars.sh "$pkgdir"/opt/devkitpro
+  install -Dm644 devkitppc.sh devkitppc.cmake gamecube.cmake wii.cmake ppcvars.sh wiivars.sh wiiuvars.sh "$pkgdir"/opt/devkitpro
   install -Dm755 meson-cross.sh meson-toolchain.sh portlibs_prefix.sh "$pkgdir"/opt/devkitpro
 
   install -Dm644 OpenGLConfig.cmake "$pkgdir"/opt/devkitpro/cmake


### PR DESCRIPTION
Not sure if this is the right way to submit this change 😂  I'm trying to make SDL for Wii install using the official build tools in case we can make it a pacman package (https://github.com/dborth/sdl-wii/issues/54) and noticed that vars file was missing.

Also I haven't changed the package version or `rel` number, happy to change those too if needed 😄 

EDIT: I just added `wiiuvars.sh` as requested 👍 