### PR TITLE
Handle `--version` for pkg-config

### DIFF
--- a/switch/pkg-config/pkg-config.in
+++ b/switch/pkg-config/pkg-config.in
@@ -8,5 +8,6 @@ export PKG_CONFIG_SYSROOT_DIR=
 
 export PKG_CONFIG_LIBDIR=${DEVKITPRO}/portlibs/switch/lib/pkgconfig
 
+[[ "$1" == '--version' ]] && exec pkg-config --version
 exec pkg-config --static "$@"
 


### PR DESCRIPTION
Some build systems (i. e. meson) try to run pkg-config with `--version` argument to check its sanity. This commit makes the wrapper handle this situation (pkg-config does not like `--version` alongside other arguments).