### PR TITLE
Add packages to support GP2X

### DIFF
--- a/gp2x-core/PKGBUILD
+++ b/gp2x-core/PKGBUILD
@@ -10,7 +10,7 @@ license=('custom')
 url="https://github.com/Orkie/gp2x-core"
 options=(!strip libtool staticlibs)
 source=(${pkgname}-${pkgver}.tar.gz::${url}/archive/v${pkgver}.tar.gz)
-sha256sums=('2d4ecd2d526a3fdf67ca8df19a1b60fe5481ee92f10bbe1b8ad41c2be9c71664')
+sha256sums=('215a4240951491f815502b5296b747b1b66791fa5a3cb5653fc52d83308d381b')
 makedepends=('devkitARM')
 groups=('gp2x-dev')
 

--- a/gp2x-core/PKGBUILD
+++ b/gp2x-core/PKGBUILD
@@ -1,0 +1,29 @@
+
+# Maintainer: Adan Scotney <adan.scotney@gmail.com
+
+pkgname=('gp2x-core')
+pkgver=1.0.0
+pkgrel=1
+pkgdesc="devkitARM gp2x-core."
+arch=('any')
+license=('custom')
+url="https://github.com/Orkie/gp2x-core"
+options=(!strip libtool staticlibs)
+source=(${pkgname}-${pkgver}.tar.gz::${url}/archive/v${pkgver}.tar.gz)
+sha256sums=('2d4ecd2d526a3fdf67ca8df19a1b60fe5481ee92f10bbe1b8ad41c2be9c71664')
+makedepends=('devkitARM')
+groups=('gp2x-dev')
+
+build() {
+
+  cd $srcdir/$pkgname-$pkgver
+  make
+
+}
+
+package() {
+
+  cd $srcdir/$pkgname-$pkgver
+  make DESTDIR=$pkgdir install
+
+}

--- a/gp2x-examples/PKGBUILD
+++ b/gp2x-examples/PKGBUILD
@@ -1,0 +1,22 @@
+
+# Maintainer: Adan Scotney <adan.scotney@gmail.com
+
+pkgname=('gp2x-examples')
+pkgver=1.0.0
+pkgrel=1
+pkgdesc="GP2X example code."
+arch=('any')
+license=('MIT')
+url="https://github.com/Orkie/gp2x-examples"
+options=(!strip libtool staticlibs)
+source=(${pkgname}-${pkgver}.tar.gz::${url}/archive/v${pkgver}.tar.gz)
+sha256sums=('5814f90bbf9f0b4bd9a477b14da1698b3112ee8e42d15f041127026da63e899d')
+makedepends=('devkitARM' 'orcus')
+
+groups=('gp32-dev')
+
+package() {
+  rm $srcdir/${pkgname}-${pkgver}.tar.gz
+  mkdir -p "$pkgdir"/opt/devkitpro/examples/gp2x
+  cp -R $srcdir/* "$pkgdir"/opt/devkitpro/examples/gp2x
+}

--- a/libfat/PKGBUILD
+++ b/libfat/PKGBUILD
@@ -18,6 +18,10 @@ elif [ "$PLATFORM" = "nds" ]; then
   platdesc="Nintendo NDS"
   makedepends=('devkitARM')
   groups=('nds-dev')
+elif [ "$PLATFORM" = "gp2x" ]; then
+  platdesc="GP2X"
+  makedepends=('devkitARM')
+  groups=('gp2x-dev')
 else
   echo "$PLATFORM unsupported"
   exit 1

--- a/liborcus/PKGBUILD
+++ b/liborcus/PKGBUILD
@@ -1,0 +1,29 @@
+
+# Maintainer: Adan Scotney <adan.scotney@gmail.com
+
+pkgname=('orcus')
+pkgver=1.0.0
+pkgrel=1
+pkgdesc="orcus"
+arch=('any')
+license=('MIT')
+url="https://github.com/Orkie/orcus"
+options=(!strip libtool staticlibs)
+source=(${pkgname}-${pkgver}.tar.gz::${url}/archive/v${pkgver}.tar.gz)
+sha256sums=('8748d8b5880c0a6143b8c0f7f80506505528b0c001918528d83c496fd068b620')
+makedepends=('devkitARM' 'gp2x-core')
+groups=('gp2x-dev')
+
+build() {
+
+  cd $srcdir/$pkgname-$pkgver
+  make
+
+}
+
+package() {
+
+  cd $srcdir/$pkgname-$pkgver
+  make DESTDIR=$pkgdir install
+
+}


### PR DESCRIPTION
This package adds contains crtls for GP2X and gp2x_rules, for use with devkitARM, within the gp2x-dev group.