### PR TITLE
switch: add libmpeg2

### DIFF
--- a/switch/libmpeg2/PKGBUILD
+++ b/switch/libmpeg2/PKGBUILD
@@ -1,0 +1,39 @@
+# Maintainer:  Dave Murphy <davem@devkitpro.org>
+# Contributor: Matthieu Milan <usineur0@gmail.com>
+
+pkgname=switch-libmpeg2
+pkgver=0.5.1
+pkgrel=1
+pkgdesc='A free MPEG-2 video stream decoder'
+arch=('any')
+url='http://libmpeg2.sourceforge.net/'
+license=('GPL')
+options=(!strip libtool staticlibs)
+source=("http://libmpeg2.sourceforge.net/files/libmpeg2-${pkgver}.tar.gz")
+sha256sums=('dee22e893cb5fc2b2b6ebd60b88478ab8556cb3b93f9a0d7ce8f3b61851871d4')
+makedepends=('switch-pkg-config' 'devkitpro-pkgbuild-helpers')
+groups=('switch-portlibs')
+
+prepare() {
+  cd libmpeg2-$pkgver
+
+  sed '/AC_PATH_XTRA/d' -i configure.ac
+  autoreconf --force --install
+}
+
+build() {
+  cd libmpeg2-$pkgver
+
+  source /opt/devkitpro/switchvars.sh
+
+  ./configure --prefix="${PORTLIBS_PREFIX}" --host=aarch64-none-elf \
+    --disable-shared --enable-static --disable-sdl
+
+  make
+}
+
+package() {
+  cd libmpeg2-$pkgver
+
+  make DESTDIR="$pkgdir" install
+}


### PR DESCRIPTION
Used by ScummVM to enable games like Escape from Monkey Island, which don't work without mpeg2.

PKGBUILD script written by @usineur