### PR TITLE
Wii: enable ModPlug support for SDL_mixer

### DIFF
--- a/wii/SDL_mixer/PKGBUILD
+++ b/wii/SDL_mixer/PKGBUILD
@@ -14,6 +14,7 @@ depends=(
  'ppc-libvorbis'
  'ppc-libogg'
  'ppc-libmad'
+ 'ppc-libmodplug'
 )
 groups=('wii-portlibs' 'wii-sdl-libs')
 
@@ -42,7 +43,7 @@ build() {
     --disable-shared --enable-static \
     --enable-music-ogg \
     --disable-music-cmd \
-    --disable-music-mod \
+    --enable-music-mod-modplug \
     --enable-music-mp3-mad-gpl
 
   make


### PR DESCRIPTION
While working on sergiou87/open-supaplex#13 I noticed SDL_mixer for Wii wasn't built with mod(plug) music support. This PR enables that.

However, before merging this, there are additional changes in devkitPPC and maybe somewhere else to fix:
1. SDL_mixer references `#include "modplug.h"` but that header is located in `libmodplug/modplug.h`
2. There is also a broken reference in `/opt/devkitpro/portlibs/ppc/lib/libmodplug.la`, where `dependency_libs` uses the wrong path.