### PR TITLE
3ds-libtheora: fix armcpu patch

### DIFF
--- a/3ds/libtheora/PKGBUILD
+++ b/3ds/libtheora/PKGBUILD
@@ -3,7 +3,7 @@
 
 pkgname=3ds-libtheora
 pkgver=1.2.0alpha1
-pkgrel=1
+pkgrel=2
 pkgdesc='Free and open video compression codec from the Xiph.org Foundation'
 arch=('any')
 url='https://www.theora.org/'
@@ -15,7 +15,7 @@ source=(
 )
 sha256sums=(
  '538305e6efa484ba740616b521f0d8c4428a0a995193c5e6af9b20f488f3c497'
- '45c9601eda3425699530edd66da0cf70658844f4cae04f4b1910d1f7f6cb2aa1'
+ 'b508af29ae3b290e0c2cb0565937826024b0acd6d8c9fb47d2abff6dd04de89a'
 )
 makedepends=('3ds-pkg-config' 'devkitpro-pkgbuild-helpers')
 depends=('3ds-libogg')

--- a/3ds/libtheora/libtheora-1.2.0.patch
+++ b/3ds/libtheora/libtheora-1.2.0.patch
@@ -1,12 +1,11 @@
 diff -Naur libtheora-1.2.0alpha1.orig/lib/arm/armcpu.c libtheora-1.2.0alpha1/lib/arm/armcpu.c
---- libtheora-1.2.0alpha1.orig/lib/arm/armcpu.c	2020-05-06 15:19:58.912792332 -0700
-+++ libtheora-1.2.0alpha1/lib/arm/armcpu.c	2020-05-06 15:17:05.241797764 -0700
-@@ -111,6 +111,20 @@
- /*The feature registers which can tell us what the processor supports are
-    accessible in priveleged modes only, so we can't have a general user-space
-    detection method like on x86.*/
--# error "Configured to use ARM asm but no CPU detection method available for " \
-- "your platform.  Reconfigure with --disable-asm (or send patches)."
+--- libtheora-1.2.0alpha1.orig/lib/arm/armcpu.c	2010-09-23 13:21:44.000000000 -0700
++++ libtheora-1.2.0alpha1/lib/arm/armcpu.c	2021-03-18 15:13:29.976897091 -0700
+@@ -107,6 +107,22 @@
+   return flags;
+ }
+ 
++#elif defined(_3DS)
 +
 +ogg_uint32_t oc_cpu_flags_get(void){
 +  ogg_uint32_t  flags;
@@ -14,14 +13,15 @@ diff -Naur libtheora-1.2.0alpha1.orig/lib/arm/armcpu.c libtheora-1.2.0alpha1/lib
 +
 +#if defined(OC_ARM_ASM_EDSP)
 +  flags|=OC_CPU_ARM_EDSP;
-+#elif defined(OC_ARM_ASM_MEDIA)
++#endif
++#if defined(OC_ARM_ASM_MEDIA)
 +  flags|=OC_ARM_ASM_MEDIA;
-+#elif defined(OC_ARM_ASM_NEON)
-+  flags|=OC_ARM_ASM_NEON;
 +#endif
 +
 +  return flags;
 +}
 +
- #endif
+ #else
+ /*The feature registers which can tell us what the processor supports are
+    accessible in priveleged modes only, so we can't have a general user-space
 


### PR DESCRIPTION
The original patch tried to claim that neon was available on the 3ds when it actually isn't. The only reason that this didn't cause a crash was due to sheer incompetence on my part.