### PR TITLE
add 3ds-libmodplug

### DIFF
--- a/3ds/libmodplug/PKGBUILD
+++ b/3ds/libmodplug/PKGBUILD
@@ -1,0 +1,40 @@
+# Maintainer:  Dave Murphy <davem@devkitpro.org>
+# Contributor: cpasjuste <cpasjuste@gmail.com>
+
+pkgname=3ds-libmodplug
+pkgver=0.8.9.0
+pkgrel=1
+pkgdesc='Play various .mod formats'
+arch=('any')
+url='http://modplug-xmms.sourceforge.net/'
+license=(public domain)
+options=(!strip libtool staticlibs)
+depends=("3ds-zlib")
+source=(
+  "https://sourceforge.net/projects/modplug-xmms/files/libmodplug/$pkgver/libmodplug-$pkgver.tar.gz"
+  "libmodplug-${pkgver}.patch"
+)
+sha256sums=(
+  '457ca5a6c179656d66c01505c0d95fafaead4329b9dbaa0f997d00a3508ad9de'
+  '21b02fafbde542e969fc41514bca7e544794110678d874fae49ce9e21cd4b342'
+)
+
+build() {
+  cd libmodplug-$pkgver
+
+  source /opt/devkitpro/devkitarm.sh
+  source /opt/devkitpro/3dsvars.sh
+
+  patch -Np1 -i "$srcdir/libmodplug-${pkgver}.patch"
+
+  ./configure --prefix="${PORTLIBS_PREFIX}" --host=arm-none-eabi \
+    --disable-shared --enable-static
+
+  make
+}
+
+package() {
+  cd libmodplug-$pkgver
+
+  make DESTDIR="$pkgdir" install
+}

--- a/3ds/libmodplug/PKGBUILD
+++ b/3ds/libmodplug/PKGBUILD
@@ -1,5 +1,5 @@
 # Maintainer:  Dave Murphy <davem@devkitpro.org>
-# Contributor: cpasjuste <cpasjuste@gmail.com>
+# Contributor: TurtleP <jpostelnek@outlook.com>
 
 pkgname=3ds-libmodplug
 pkgver=0.8.9.0
@@ -10,6 +10,7 @@ url='http://modplug-xmms.sourceforge.net/'
 license=(public domain)
 options=(!strip libtool staticlibs)
 depends=("3ds-zlib")
+groups=('3ds-portlibs')
 source=(
   "https://sourceforge.net/projects/modplug-xmms/files/libmodplug/$pkgver/libmodplug-$pkgver.tar.gz"
   "libmodplug-${pkgver}.patch"
@@ -22,7 +23,6 @@ sha256sums=(
 build() {
   cd libmodplug-$pkgver
 
-  source /opt/devkitpro/devkitarm.sh
   source /opt/devkitpro/3dsvars.sh
 
   patch -Np1 -i "$srcdir/libmodplug-${pkgver}.patch"

--- a/3ds/libmodplug/libmodplug-0.8.9.0.patch
+++ b/3ds/libmodplug/libmodplug-0.8.9.0.patch
@@ -1,0 +1,42 @@
+diff -Naur libmodplug-0.8.9.0.old/src/load_abc.cpp libmodplug-0.8.9.0/src/load_abc.cpp
+--- libmodplug-0.8.9.0.old/src/load_abc.cpp	2020-10-08 22:58:42.530000706 +0200
++++ libmodplug-0.8.9.0/src/load_abc.cpp	2020-10-08 22:59:20.744998238 +0200
+@@ -3597,8 +3597,10 @@
+ 	mm.mm = (char *)lpStream;
+ 	mm.sz = dwMemLength;
+ 	mm.pos = 0;
++#ifndef __3DS__
+ 	while( avoid_reentry ) sleep(1);
+ 	avoid_reentry = 1;
++#endif
+ 	pat_resetsmp();
+ 	pat_init_patnames();
+ 	m_nDefaultTempo = 0;
+diff -Naur libmodplug-0.8.9.0.old/src/load_mid.cpp libmodplug-0.8.9.0/src/load_mid.cpp
+--- libmodplug-0.8.9.0.old/src/load_mid.cpp	2020-10-08 22:58:42.530000706 +0200
++++ libmodplug-0.8.9.0/src/load_mid.cpp	2020-10-08 22:59:30.568997604 +0200
+@@ -1170,8 +1170,10 @@
+ 	BYTE midibyte[2];
+ 	long metalen, delta;
+ 	BYTE *p;
++#ifndef __3DS__
+ 	while( avoid_reentry ) sleep(1);
+ 	avoid_reentry = 1;
++#endif
+ 	if( !TestMID(lpStream, dwMemLength) ) {
+ 		avoid_reentry = 0;
+ 		return FALSE;
+diff -Naur libmodplug-0.8.9.0.old/src/load_pat.cpp libmodplug-0.8.9.0/src/load_pat.cpp
+--- libmodplug-0.8.9.0.old/src/load_pat.cpp	2020-10-08 22:58:42.531000706 +0200
++++ libmodplug-0.8.9.0/src/load_pat.cpp	2020-10-08 22:59:26.472997869 +0200
+@@ -1149,8 +1149,10 @@
+ 	mm.sz = dwMemLength;
+ 	mm.pos = 0;
+ 	mm.error = 0;
++#ifndef __3DS__
+ 	while( avoid_reentry ) sleep(1);
+ 	avoid_reentry = 1;
++#endif
+ 	pat_read_patname(h, mmfile);
+ 	h->samples = pat_read_numsmp(mmfile);
+ 	if( strlen(h->patname) )


### PR DESCRIPTION
## About
This pull request aims to add libmodplug to the 3ds packages. Tested locally on my own 3DS. Audio plays as expected.

## Example Code
[3ds-libmodplug-example.zip](https://github.com/devkitPro/pacman-packages/files/6611872/3ds-libmodplug-example.zip)

## Hardware Test
https://streamable.com/38pnl3
