### PR TITLE
3ds: add wslay and nettle

### DIFF
--- a/3ds/wslay/PKGBUILD
+++ b/3ds/wslay/PKGBUILD
@@ -9,7 +9,7 @@ url='https://github.com/tatsuhiro-t/wslay'
 license=('MIT')
 options=(!strip libtool staticlibs)
 groups=('3ds-portlibs')
-makedepends=('3ds-pkg-config' 'devkitpro-pkgbuild-helpers')
+makedepends=('3ds-pkg-config' 'dkp-toolchain-vars')
 source=("https://github.com/tatsuhiro-t/wslay/releases/download/release-${pkgver}/wslay-${pkgver}.tar.gz")
 sha256sums=('90CE68C6DFD614722D44FBB14563A3F6DACC68B548B20AE382AC4F4952C55268')
 build() {

--- a/3ds/wslay/PKGBUILD
+++ b/3ds/wslay/PKGBUILD
@@ -1,0 +1,36 @@
+# Maintainer:  Dave Murphy <davem@devkitpro.org>
+
+pkgname=3ds-wslay
+pkgver=1.1.1
+pkgrel=1
+pkgdesc='Wslay is a WebSocket library written in C.'
+arch=('any')
+url='https://github.com/tatsuhiro-t/wslay'
+license=('MIT')
+options=(!strip libtool staticlibs)
+groups=('3ds-portlibs')
+makedepends=('3ds-pkg-config' 'devkitpro-pkgbuild-helpers')
+source=("https://github.com/tatsuhiro-t/wslay/releases/download/release-${pkgver}/wslay-${pkgver}.tar.gz")
+sha256sums=('90CE68C6DFD614722D44FBB14563A3F6DACC68B548B20AE382AC4F4952C55268')
+build() {
+  cd wslay-$pkgver
+
+  source /opt/devkitpro/3dsvars.sh
+
+  ./configure --prefix="${PORTLIBS_PREFIX}" --host=arm-none-eabi \
+    --disable-shared --enable-static
+
+  make
+}
+
+package() {
+  cd wslay-$pkgver
+
+  source /opt/devkitpro/3dsvars.sh
+
+  make DESTDIR="$pkgdir" install
+  # license
+  install -Dm644 COPYING "$pkgdir"${PORTLIBS_PREFIX}/licenses/$pkgname/COPYING
+  # remove useless stuff
+  rm -r "$pkgdir"${PORTLIBS_PREFIX}/share
+}


### PR DESCRIPTION
Here is a working example program, adapted from wslay's examples, with the 3ds connecting to a websocat server: [wslay-client.zip](https://github.com/devkitPro/pacman-packages/files/6673296/wslay-client.zip)

`gcc` is in nettle's `makedepends` because it seems nettle needs to build utilities to run on the build system at build time.

Please feel free to make any changes.