### PR TITLE
switch-libmad: force PIC compilation

### DIFF
--- a/switch/libmad/PKGBUILD
+++ b/switch/libmad/PKGBUILD
@@ -28,7 +28,7 @@ build() {
 
   source ${DEVKITPRO}/switchvars.sh
 
-  ./configure --prefix="${PORTLIBS_PREFIX}" --host=aarch64-none-elf --disable-shared --enable-static
+  ./configure --prefix="${PORTLIBS_PREFIX}" --host=aarch64-none-elf --disable-shared --enable-static --with-pic=yes
   make
 }
 


### PR DESCRIPTION
devkitA64 provides a libmad compiled without the -fPIC flag.
It means that linking fails with error "read-only segment has dynamic relocations".
This is due to configure script which filters out -fPIC flag because it handles it itself.
To fix this, configure must be run with --with-pic=yes option.