### PR TITLE
Fix some SDL packages with misleading descriptions

### DIFF
--- a/gamecube/SDL/PKGBUILD
+++ b/gamecube/SDL/PKGBUILD
@@ -4,7 +4,7 @@
 pkgname=gamecube-sdl
 pkgver=1.2.15
 pkgrel=3
-pkgdesc="A library for portable low-level access to a video framebuffer, audio output, mouse, and keyboard (Nintendo Wii port)"
+pkgdesc="A library for portable low-level access to a video framebuffer, audio output, mouse, and keyboard (Nintendo Gamecube port)"
 arch=('any')
 url="https://libsdl.org"
 license=("LGPL")

--- a/gamecube/SDL_ttf/PKGBUILD
+++ b/gamecube/SDL_ttf/PKGBUILD
@@ -3,7 +3,7 @@
 pkgname=gamecube-sdl_ttf
 pkgver=2.0.11
 pkgrel=2
-pkgdesc="A sample library which allows you to use TrueType fonts in your SDL applications (Nintendo 3DS port)"
+pkgdesc="A sample library which allows you to use TrueType fonts in your SDL applications (Nintendo Gamecube port)"
 arch=('any')
 url="https://libsdl.org"
 license=("LGPL")

--- a/wii/SDL_ttf/PKGBUILD
+++ b/wii/SDL_ttf/PKGBUILD
@@ -3,7 +3,7 @@
 pkgname=wii-sdl_ttf
 pkgver=2.0.11
 pkgrel=3
-pkgdesc="A sample library which allows you to use TrueType fonts in your SDL applications (Nintendo 3DS port)"
+pkgdesc="A sample library which allows you to use TrueType fonts in your SDL applications (Nintendo Wii port)"
 arch=('any')
 url="https://libsdl.org"
 license=("LGPL")


### PR DESCRIPTION
The Gamecube SDL and SDL_ttf packages, and the Wii SDL_ttf package have descriptions which refer to the wrong console. 

This confused me for a second, so here's a fix.