### PR TITLE
switch-libtheora: upgrade to 1.2.0alpha1

### DIFF
--- a/switch/libtheora/PKGBUILD
+++ b/switch/libtheora/PKGBUILD
@@ -2,7 +2,7 @@
 
 pkgname=switch-libtheora
 pkgver=1.2.0alpha1
-pkgrel=3
+pkgrel=1
 pkgdesc='Free and open video compression codec from the Xiph.org Foundation'
 arch=('any')
 url='https://www.theora.org/'

--- a/switch/libtheora/PKGBUILD
+++ b/switch/libtheora/PKGBUILD
@@ -1,18 +1,18 @@
 # Maintainer:  Dave Murphy <davem@devkitpro.org>
 
 pkgname=switch-libtheora
-pkgver=1.1.1
-pkgrel=2
+pkgver=1.2.0alpha1
+pkgrel=3
 pkgdesc='Free and open video compression codec from the Xiph.org Foundation'
 arch=('any')
 url='https://www.theora.org/'
 license=(Xiph.org)
 options=(!strip libtool staticlibs)
-source=("http://downloads.xiph.org/releases/theora/libtheora-${pkgver}.tar.bz2" "config.sub" "config.guess")
+source=("https://ftp.osuosl.org/pub/xiph/releases/theora/libtheora-${pkgver}.tar.gz" "config.sub" "config.guess")
 sha256sums=(
- 'b6ae1ee2fa3d42ac489287d3ec34c5885730b1296f0801ae577a35193d3affbc'
- '72e02ea93447038f8ced24f296b31e0f397bbcc6b32abdcf9b38c80f153433fd'
- 'fbc2337aa59a204f5d74743b82c8be7aab8b39853b4e54a888008f70430c4305'
+ '538305e6efa484ba740616b521f0d8c4428a0a995193c5e6af9b20f488f3c497'
+ '20a4eaedc9fb93161c214379e22e2bc60f238b1caef352c04b4e2df79e8a3ead'
+ '754b72ef1172b2ecf6ed167d731fcb7ff19a4c2786ff0f24a8ce5c36be8d7783'
 )
 
 makedepends=('switch-pkg-config' 'dkp-toolchain-vars')


### PR DESCRIPTION
This pull request upgrades switch-libtheora to 1.2.0alpha1. It puts it in line with the 3ds version. It builds and works on-console. Originally I was using switch-libtheora1.1, but this was crashing on `th_decode_packetin`. This actually fixes that. Although I cannot be sure that maybe the old 1.1 package was built incorrectly, for example.