### PR TITLE
Add devkitarm-rules to makedepends of devkitarm-crtls

### DIFF
--- a/devkitarm/devkitarm-crtls/PKGBUILD
+++ b/devkitarm/devkitarm-crtls/PKGBUILD
@@ -11,7 +11,7 @@ url="http://github.com/devkitpro/devkitarm-crtls"
 options=(!strip libtool staticlibs)
 source=(${pkgname}-${pkgver}.tar.gz::${url}/archive/refs/tags/v${pkgver}.tar.gz)
 sha256sums=('851b042662dc32cde331c3afceb15988793fe3a83d24ac83dd48e9223b24bf3b')
-makedepends=('devkitARM')
+makedepends=('devkitARM' 'devkitarm-rules')
 groups=('gba-dev' 'gp32-dev' 'nds-dev' '3ds-dev')
 
 build() {


### PR DESCRIPTION
During the build phase of devkitarm-crtls the 'base_rules' of the
toolchain, provided by devkitarm-rules, are required.

Therefore devkitarm-rules must've been installed prior.