### PR TITLE
dkp-cmake-common-utils: use TO_CMAKE_PATH to escape windows path

### DIFF
--- a/cmake/common-utils/PKGBUILD
+++ b/cmake/common-utils/PKGBUILD
@@ -17,7 +17,7 @@ source=(
 )
 
 sha256sums=(
-  'ec758b41e5a58b288cf08ef27ce9b8791ff0411aa957141f1f73ca3e97fcdf6f'  # dkp-initialize-path.cmake
+  'f20279873542e4e50e64036f8b68a33fd1e4aa3d45a98e233e5dd9d0ebd97ca3'  # dkp-initialize-path.cmake
   '6bc88ff01d63cbed885dc964fae95667211c1f3fae897e6e24d6fc380ea632f7'  # dkp-toolchain-common.cmake
   '77d8afc4add9aa90bfda1eae71904ae17c51464acb98b36f441cfba544b258ce'  # dkp-rule-overrides.cmake
   '24f0d66c643ea7145ad9d5698f00b18b30583145c63642da553429075f4cf556'  # dkp-linker-utils.cmake

--- a/cmake/common-utils/dkp-initialize-path.cmake
+++ b/cmake/common-utils/dkp-initialize-path.cmake
@@ -3,7 +3,7 @@ cmake_minimum_required(VERSION 3.13)
 if(NOT DEFINED ENV{DEVKITPRO})
 	set(DEVKITPRO /opt/devkitpro)
 else()
-	set(DEVKITPRO $ENV{DEVKITPRO})
+	file(TO_CMAKE_PATH $ENV{DEVKITPRO} DEVKITPRO)
 endif()
 
 list(APPEND CMAKE_MODULE_PATH "${DEVKITPRO}/cmake")


### PR DESCRIPTION
I'm using dkp on msys2(windows 10).

I set environment variable(DEVKITPRO, DEVKITARM) using backslash as a path separator.
And I got an error related to it.

```
[proc] Executing command: "C:\Program Files\CMake\bin\cmake.EXE" --no-warn-unused-cli -DCMAKE_TOOLCHAIN_FILE=C:/msys64/opt/devkitpro/cmake/3DS.cmake -DCMAKE_MAKE_PROGRAM=C:\msys64/usr/bin/make.exe -DCMAKE_EXPORT_COMPILE_COMMANDS:BOOL=TRUE -DCMAKE_BUILD_TYPE:STRING=Debug -Sc:/<PROJECT_DIR> -Bc:/<PROJECT_DIR>/build -G "Unix Makefiles"
[cmake] Not searching for unused variables given on the command line.
[cmake] CMake Error at C:/msys64/opt/devkitpro/cmake/dkp-toolchain-common.cmake:72 (list):
[cmake]   Syntax error in cmake code at
[cmake] 
[cmake]     C:/msys64/opt/devkitpro/cmake/dkp-toolchain-common.cmake:72
[cmake] 
[cmake]   when parsing string
[cmake] 
[cmake]     C:\msys64\opt\devkitpro/portlibs/3ds;C:\msys64\opt\devkitpro/libctru
[cmake] 
[cmake]   Invalid character escape '\m'.
[cmake] Call Stack (most recent call first):
[cmake]   C:/msys64/opt/devkitpro/cmake/3DS.cmake:16 (__dkp_platform_prefix)
[cmake]   CMakeLists.txt:9 (include)
[cmake] 
[cmake] 
[cmake] -- Configuring incomplete, errors occurred!
[cmake] See also "C:/<PROJECT_DIR>/build/CMakeFiles/CMakeOutput.log".
```


So, I fixed some for it.