### PR TITLE
Add missing library path in CafeOS.cmake

### DIFF
--- a/cmake/wiiu/CafeOS.cmake
+++ b/cmake/wiiu/CafeOS.cmake
@@ -16,7 +16,7 @@ set(WUT TRUE)
 # Platform settings
 set(WUT_ARCH_SETTINGS "-mcpu=750 -meabi -mhard-float")
 set(WUT_COMMON_FLAGS  "-ffunction-sections -fdata-sections -DESPRESSO -D__WIIU__ -D__WUT__")
-set(WUT_LINKER_FLAGS  "-L${WUT_ROOT}/lib -L${DEVKITPRO}/portlibs/wiiu/lib -specs=${WUT_ROOT}/share/wut.specs")
+set(WUT_LINKER_FLAGS  "-L${WUT_ROOT}/lib -L${DEVKITPRO}/portlibs/wiiu/lib -L${DEVKITPRO}/portlibs/ppc/lib -specs=${WUT_ROOT}/share/wut.specs")
 set(WUT_STANDARD_LIBRARIES "-lwut -lm")
 set(WUT_STANDARD_INCLUDE_DIRECTORIES "${WUT_ROOT}/include")
 

--- a/cmake/wiiu/PKGBUILD
+++ b/cmake/wiiu/PKGBUILD
@@ -1,7 +1,7 @@
 # Maintainer: fincs <fincs@devkitpro.org>
 pkgname=wiiu-cmake
 pkgver=1.1.1
-pkgrel=1
+pkgrel=2
 pkgdesc="CMake support for Nintendo Wii U"
 arch=('any')
 url='https://devkitpro.org/'
@@ -17,7 +17,7 @@ options=('!strip')
 sha256sums=(
   'f17d338c2c6416099a264855336d915ce2d70071b356e9d13b8f712b9daa1730' # powerpc-eabi-cmake
   '00b58a68455f1395001b538e29d018026da48751247d8da7a36e63a165ea1032' # WiiU.cmake
-  '37e95ed2e99b12b3bca8401de0715072c6c4d4276b8e0fe5a0061fed14f0cdb4' # CafeOS.cmake
+  '718742d8dbe4c7cda05bea52c91ddf2ca8752ff8a47bef4d56ff8387d025dab2' # CafeOS.cmake
 )
 
 package() {


### PR DESCRIPTION
I'm not that much familiar with cmake, so if this PR is not accurate, simply close it 😁

There are a few libraries installed with the wiiu-dev package that are getting installed into the _${DEVKITPRO}/portlibs/ppc/lib_ folder. So I guess that this folder should also be included with the others WUT_LINKER_FLAGS.