### PR TITLE
cmake: Make platform ID flags cached

### DIFF
--- a/cmake/3ds/Nintendo3DS.cmake
+++ b/cmake/3ds/Nintendo3DS.cmake
@@ -8,7 +8,7 @@ include_guard(GLOBAL)
 include(Platform/Generic-dkP)
 
 # Platform identification flags
-set(NINTENDO_3DS TRUE)
+set(NINTENDO_3DS CACHE BOOL TRUE)
 
 # Platform settings
 set(CTR_ARCH_SETTINGS "-march=armv6k -mtune=mpcore -mfloat-abi=hard -mtp=soft")

--- a/cmake/gamecube/NintendoGameCube.cmake
+++ b/cmake/gamecube/NintendoGameCube.cmake
@@ -5,7 +5,7 @@ cmake_minimum_required(VERSION 3.13)
 include_guard(GLOBAL)
 
 # Platform identification flags
-set(NINTENDO_GAMECUBE TRUE)
+set(NINTENDO_GAMECUBE CACHE BOOL TRUE)
 
 # Inherit libogc platform configuration
 include(Platform/libogc)

--- a/cmake/nds/NintendoDS.cmake
+++ b/cmake/nds/NintendoDS.cmake
@@ -8,7 +8,7 @@ include_guard(GLOBAL)
 include(Platform/Generic-dkP)
 
 # Platform identification flags
-set(NINTENDO_DS TRUE)
+set(NINTENDO_DS CACHE BOOL TRUE)
 
 # Platform settings
 set(NDS_STANDARD_INCLUDE_DIRECTORIES "${NDS_ROOT}/include")

--- a/cmake/switch/NintendoSwitch.cmake
+++ b/cmake/switch/NintendoSwitch.cmake
@@ -8,7 +8,7 @@ include_guard(GLOBAL)
 include(Platform/Generic-dkP)
 
 # Platform identification flags
-set(NINTENDO_SWITCH TRUE)
+set(NINTENDO_SWITCH CACHE BOOL TRUE)
 
 # Platform settings
 set(NX_ARCH_SETTINGS "-march=armv8-a+crc+crypto -mtune=cortex-a57 -mtp=soft -ftls-model=local-exec")

--- a/cmake/wii/NintendoWii.cmake
+++ b/cmake/wii/NintendoWii.cmake
@@ -5,7 +5,7 @@ cmake_minimum_required(VERSION 3.13)
 include_guard(GLOBAL)
 
 # Platform identification flags
-set(NINTENDO_WII TRUE)
+set(NINTENDO_WII CACHE BOOL TRUE)
 set(OGC_EXTRA_LIBS "-lwiiuse -lbte")
 
 # Inherit libogc platform configuration

--- a/cmake/wiiu/CafeOS.cmake
+++ b/cmake/wiiu/CafeOS.cmake
@@ -8,10 +8,10 @@ include_guard(GLOBAL)
 include(Platform/Generic-dkP)
 
 # Platform identification flags
-set(CAFEOS TRUE)
-set(NINTENDO_WIIU TRUE)
-set(WIIU TRUE)
-set(WUT TRUE)
+set(CAFEOS CACHE BOOL TRUE)
+set(NINTENDO_WIIU CACHE BOOL TRUE)
+set(WIIU CACHE BOOL TRUE)
+set(WUT CACHE BOOL TRUE)
 
 # Platform settings
 set(WUT_ARCH_SETTINGS "-mcpu=750 -meabi -mhard-float")


### PR DESCRIPTION
I found that there wasn't any easy type of define given for platform flags. When coding a multi platform header, it would make things a lot simpler if a define like NINTENDO_WII was made so somebody could use macros to determine dependencies or platform specific functionality. Ex.

```
#ifdef NINTENDO_WII
   #include <gccore.h>
#else
   #include <cstdint> 
   typedef int8_t s8;
#endif
```