### PR TITLE
switch: add ntfs-3g

### DIFF
--- a/switch/ntfs-3g/PKGBUILD
+++ b/switch/ntfs-3g/PKGBUILD
@@ -1,0 +1,58 @@
+# Maintainer: Rhys Koedijk <rhys@koedijk.co.nz>
+# Maintainer: DarkMatterCore <pabloacurielz@gmail.com>
+
+pkgname=switch-ntfs-3g
+pkgver=2022.10.3
+pkgrel=1
+pkgdesc='An open source, freely available read/write NTFS driver'
+arch=('any')
+url='https://www.tuxera.com/community/open-source-ntfs-3g/'
+license=('GPL')
+options=(!strip libtool staticlibs)
+groups=('switch-portlibs')
+makedepends=('devkitA64' 'dkp-toolchain-vars')
+
+source=(
+  "ntfs-3g-${pkgver}.tar.gz::https://github.com/tuxera/ntfs-3g/archive/refs/tags/${pkgver}.tar.gz"
+  "ntfs-3g-${pkgver}.patch"
+)
+
+sha256sums=(
+  '8bd7749ea9d8534c9f0664d48b576e90b96d45ec8803c9427f6ffaa2f0dde299'
+  '66962f5632b3d24dacf178cc136e302038f2ed3ae8306ba9407695a77f369ebd'
+)
+
+prepare() {
+  cd "ntfs-3g-${pkgver}"
+  patch -Np1 -i "${srcdir}/ntfs-3g-${pkgver}.patch"
+  ./autogen.sh
+}
+
+build() {
+  cd "ntfs-3g-${pkgver}"
+
+  source /opt/devkitpro/switchvars.sh
+
+  CPPFLAGS=-I/opt/devkitpro/libnx/include ./configure --prefix="${PORTLIBS_PREFIX}" \
+    --host=aarch64-none-elf \
+    --disable-shared \
+    --enable-static \
+    --disable-ntfsprogs \
+    --disable-ntfs-3g \
+    --disable-device-default-io-ops \
+    --disable-plugins \
+    --without-uuid \
+    --without-hd
+
+  make
+}
+
+package() {
+  cd "ntfs-3g-${pkgver}"
+
+  source /opt/devkitpro/switchvars.sh
+
+  install -Dm644 COPYING "${pkgdir}${PORTLIBS_PREFIX}/licenses/${pkgname}/COPYING"
+
+  rm -fr "${pkgdir}${PORTLIBS_PREFIX}/share"
+}

--- a/switch/ntfs-3g/ntfs-3g-2022.10.3.patch
+++ b/switch/ntfs-3g/ntfs-3g-2022.10.3.patch
@@ -1,0 +1,29 @@
+diff --git a/include/ntfs-3g/ntfstime.h b/include/ntfs-3g/ntfstime.h
+index f3a89dd8..ce0d4586 100644
+--- a/include/ntfs-3g/ntfstime.h
++++ b/include/ntfs-3g/ntfstime.h
+@@ -36,6 +36,10 @@
+ 
+ #include "types.h"
+ 
++#ifdef _SYS__TIMESPEC_H_
++#define __timespec_defined
++#endif
++
+ /*
+  * assume "struct timespec" is not defined if st_mtime is not defined
+  */
+diff --git a/libntfs-3g/ioctl.c b/libntfs-3g/ioctl.c
+index b059a53f..a3a56722 100644
+--- a/libntfs-3g/ioctl.c
++++ b/libntfs-3g/ioctl.c
+@@ -48,7 +48,9 @@
+ #ifdef HAVE_LIMITS_H
+ #include <limits.h>
+ #endif
++#ifdef HAVE_SYSLOG_H
+ #include <syslog.h>
++#endif
+ #ifdef HAVE_SYS_TYPES_H
+ #include <sys/types.h>
+ #endif


### PR DESCRIPTION
Based on the original PKGBUILD script + patch from the libusbhsfs repository, plus some extra modifications based on the PPC portlib.

References:

* https://github.com/devkitPro/docker/pull/28
* https://devkitpro.org/viewtopic.php?p=17868