### PR TITLE
switch-libass: 0.17.2

### DIFF
--- a/switch/libass/PKGBUILD
+++ b/switch/libass/PKGBUILD
@@ -1,38 +1,36 @@
 # Maintainer: Dave Murphy <davem@devkitpro.org>
 # Contributor: carstene1ns <dev f4ke de>
 
-pkgname=switch-libass
-pkgver=0.14.0
-pkgrel=2
+pkgbasename=libass
+pkgname=switch-$pkgbasename
+pkgver=0.17.2
+pkgrel=1
 pkgdesc='A portable subtitle renderer (Nintendo Switch port)'
 arch=('any')
 url="https://github.com/libass/libass"
 license=('custom: ISC')
-options=(!strip staticlibs)
+options=(!strip libtool staticlibs)
 depends=('switch-freetype' 'switch-libfribidi')
-makedepends=('switch-pkg-config' 'dkp-toolchain-vars')
-source=("https://github.com/libass/libass/releases/download/$pkgver/libass-$pkgver.tar.xz")
-sha256sums=('881f2382af48aead75b7a0e02e65d88c5ebd369fe46bc77d9270a94aa8fd38a2')
+makedepends=('dkp-toolchain-vars' 'switch-pkg-config')
+source=("$url/releases/download/$pkgver/$pkgbasename-$pkgver.tar.gz")
 groups=('switch-portlibs')
 
 build() {
-  cd libass-$pkgver
+  cd $pkgbasename-$pkgver
 
-  source /opt/devkitpro/devkita64.sh
   source /opt/devkitpro/switchvars.sh
 
   ./configure --prefix="$PORTLIBS_PREFIX" --host=aarch64-none-elf \
     --disable-shared --enable-static \
-    --disable-asm --enable-large-tiles \
+    --enable-asm --enable-large-tiles \
     --disable-require-system-font-provider
 
   make
 }
 
 package() {
-  cd libass-$pkgver
+  cd $pkgbasename-$pkgver
 
-  source /opt/devkitpro/devkita64.sh
   source /opt/devkitpro/switchvars.sh
 
   make DESTDIR="$pkgdir" install
@@ -40,3 +38,5 @@ package() {
   # license
   install -Dm644 "COPYING" "$pkgdir/$PORTLIBS_PREFIX/licenses/$pkgname/COPYING"
 }
+
+sha256sums=('a9afb52bf76a2569263fe2038896774c991b35c0968342a03be708e56ea60c3b')


### PR DESCRIPTION
With its [0.17.2](https://github.com/libass/libass/releases/tag/0.17.2) release libass added optimized assembly routines for aarch64, greatly improving rendering performance.