### PR TITLE
Basic port of curl and mbedtls to NDS

### DIFF
--- a/nds/curl/PKGBUILD
+++ b/nds/curl/PKGBUILD
@@ -1,0 +1,85 @@
+# Maintainer: WinterMute <davem@devkitpro.org>
+# Contributor: ds-sloth
+
+pkgname=nds-curl
+pkgver=7.83.0
+pkgrel=1
+pkgdesc='This build includes only the HTTP/HTTPS, FTP/FTPS, and FILE protocols for codesize.'
+arch=('any')
+url='https://curl.haxx.se/'
+license=('MIT')
+options=(!strip libtool staticlibs)
+depends=(
+         "nds-mbedtls"
+         "dswifi"
+)
+makedepends=('nds-mbedtls' 'dswifi' 'nds-pkg-config' 'dkp-toolchain-vars')
+source=(
+  "https://curl.se/download/curl-$pkgver.tar.gz"
+  "curl.patch"
+)
+sha256sums=(
+  'c0e64302a33d2fb79e0fc4e674260a22941e92ee2f11b894bf94d32b8f5531af'
+  'eb32a445dbfeca3c0e71b0e06fd71367486357464e8fb6a274fa3934c88b9b18'
+)
+groups=("nds-portlibs")
+
+prepare() {
+  patch --directory="${srcdir}/curl-${pkgver}" --forward --strip=1 --input="${srcdir}/curl.patch"
+}
+
+build() {
+  cd curl-$pkgver
+
+  source /opt/devkitpro/ndsvars.sh
+
+  # important note: including ${DEVKITPRO}/libnds/include/sys/ is absolutely necessary; without this, closesocket is not detected
+
+  export CFLAGS="${CFLAGS} -Os"
+  export CPPFLAGS="${CPPFLAGS} -DIPPROTO_UDP=17 -DIPPROTO_TCP=6 -DMBEDTLS_ALLOW_PRIVATE_ACCESS -I${DEVKITPRO}/libnds/include/sys/"
+  export LIBS="-ldswifi9 -lnds9 -lcalico_ds9 ${LIBS}"
+  export LDFLAGS="${LDFLAGS} -Oz -L${DEVKITPRO}/calico/lib -specs=${DEVKITPRO}/calico/share/ds9.specs"
+
+  ./configure --prefix="${PORTLIBS_PREFIX}" --host=arm-none-eabi \
+    --disable-shared --enable-static \
+    --disable-ipv6 --with-mbedtls=${PORTLIBS_PREFIX} \
+    --disable-unix-sockets \
+    --disable-socketpair \
+    --disable-ntlm \
+    --disable-ntlm-wb \
+    --disable-dict \
+    --disable-gopher \
+    --disable-imap \
+    --disable-ldap \
+    --disable-ldaps \
+    --disable-mqtt \
+    --disable-pop3 \
+    --disable-rtsp \
+    --disable-scp \
+    --disable-sftp \
+    --disable-smb \
+    --disable-smtp \
+    --disable-telnet \
+    --disable-tftp \
+    --disable-mime \
+    --disable-progress-meter \
+    --disable-netrc \
+    --with-ca-bundle="/cacert.pem"
+
+  make DESTDIR="$pkgdir" -C lib
+}
+
+package() {
+  cd curl-$pkgver
+
+  source /opt/devkitpro/ndsvars.sh
+
+  make DESTDIR="$pkgdir" -C lib install
+
+  make DESTDIR="$pkgdir" -C include install
+
+  make DESTDIR="$pkgdir" install-binSCRIPTS install-pkgconfigDATA
+
+  # Licenses
+  install -Dm644 "COPYING" "${pkgdir}/${PORTLIBS_PREFIX}/licenses/${pkgname}/COPYING"
+}

--- a/nds/curl/curl.patch
+++ b/nds/curl/curl.patch
@@ -1,0 +1,13 @@
+diff --git a/lib/nonblock.c b/lib/nonblock.c
+index 28f6e75..b8a5267 100644
+--- a/lib/nonblock.c
++++ b/lib/nonblock.c
+@@ -47,7 +47,7 @@
+ int curlx_nonblock(curl_socket_t sockfd,    /* operate on this */
+                    int nonblock   /* TRUE or FALSE */)
+ {
+-#if defined(HAVE_FCNTL_O_NONBLOCK)
++#if defined(HAVE_FCNTL_O_NONBLOCK) && !defined(__NDS__)
+   /* most recent unix versions */
+   int flags;
+   flags = sfcntl(sockfd, F_GETFL, 0);

--- a/nds/mbedtls/PKGBUILD
+++ b/nds/mbedtls/PKGBUILD
@@ -1,0 +1,51 @@
+# Maintainer: WinterMute <davem@devkitpro.org>
+# Contributor: ds-sloth
+
+pkgname=nds-mbedtls
+pkgver=3.1.0
+pkgrel=1
+pkgdesc='Provides a minimal SSL/TLS layer for embedded devices. Warning: takes ownership of the microphone while in use.'
+arch=('any')
+url='https://tls.mbed.org/'
+license=('Apache')
+options=(!strip libtool staticlibs)
+depends=(
+         "libnds" "calico" "dswifi"
+)
+makedepends=('nds-pkg-config' 'dkp-toolchain-vars')
+source=(
+  "https://github.com/Mbed-TLS/mbedtls/archive/refs/tags/v${pkgver}.tar.gz"
+  "mbedtls.patch"
+)
+sha256sums=(
+  'b02df6f68dd1537e115a8497d5c173dc71edc55ad084756e57a30f951b725acd'
+  '1a29761630e9b86a08f35f346b044fa11f6363bdc39cbf866333e37ebdd01ff8'
+)
+groups=("nds-portlibs")
+
+prepare() {
+  patch --directory="${srcdir}/mbedtls-$pkgver" --forward --strip=1 --input="${srcdir}/mbedtls.patch"
+}
+
+build() {
+  cd mbedtls-$pkgver
+
+  source /opt/devkitpro/ndsvars.sh
+  export CFLAGS="${CFLAGS} ${CPPFLAGS} -I${DEVKITPRO}/calico/include -Os"
+
+  make DESTDIR="$pkgdir/${PORTLIBS_PREFIX}" lib
+}
+
+package() {
+  cd mbedtls-$pkgver
+
+  source /opt/devkitpro/ndsvars.sh
+
+  make DESTDIR="$pkgdir/${PORTLIBS_PREFIX}" lib install
+
+  # Licenses
+  install -Dm644 "LICENSE" "${pkgdir}/${PORTLIBS_PREFIX}/licenses/${pkgname}/LICENSE"
+
+  # remove useless stuff
+  rm -r ${pkgdir}/${PORTLIBS_PREFIX}/bin/
+}

--- a/nds/mbedtls/mbedtls.patch
+++ b/nds/mbedtls/mbedtls.patch
@@ -1,0 +1,204 @@
+diff --git a/Makefile b/Makefile
+index 5b2ad16..73fcb0a 100644
+--- a/Makefile
++++ b/Makefile
+@@ -55,7 +55,7 @@ $(VISUALC_FILES):
+ 	$(PERL) scripts/generate_visualc_files.pl
+ 
+ ifndef WINDOWS
+-install: no_test
++install: lib
+ 	mkdir -p $(DESTDIR)/include/mbedtls
+ 	cp -rp include/mbedtls $(DESTDIR)/include
+ 	mkdir -p $(DESTDIR)/include/psa
+diff --git a/include/mbedtls/mbedtls_config.h b/include/mbedtls/mbedtls_config.h
+index 0558ee0..0e04e45 100644
+--- a/include/mbedtls/mbedtls_config.h
++++ b/include/mbedtls/mbedtls_config.h
+@@ -467,7 +467,7 @@
+  *
+  * Uncomment to use your own hardware entropy collector.
+  */
+-//#define MBEDTLS_ENTROPY_HARDWARE_ALT
++#define MBEDTLS_ENTROPY_HARDWARE_ALT
+ 
+ /**
+  * \def MBEDTLS_AES_ROM_TABLES
+@@ -1027,7 +1027,7 @@
+  *
+  * Uncomment this macro to disable the built-in platform entropy functions.
+  */
+-//#define MBEDTLS_NO_PLATFORM_ENTROPY
++#define MBEDTLS_NO_PLATFORM_ENTROPY
+ 
+ /**
+  * \def MBEDTLS_ENTROPY_FORCE_SHA256
+@@ -2604,7 +2604,7 @@
+  *
+  * This module enables abstraction of common (libc) functions.
+  */
+-#define MBEDTLS_PLATFORM_C
++// #define MBEDTLS_PLATFORM_C
+ 
+ /**
+  * \def MBEDTLS_POLY1305_C
+@@ -2850,7 +2850,7 @@
+  *
+  * This module is required for SSL/TLS server support.
+  */
+-#define MBEDTLS_SSL_SRV_C
++// #define MBEDTLS_SSL_SRV_C
+ 
+ /**
+  * \def MBEDTLS_SSL_TLS_C
+diff a/library/entropy_poll.c b/library/entropy_poll.c
+--- a/library/entropy_poll.c
++++ b/library/entropy_poll.c
+@@ -234,4 +234,65 @@ int mbedtls_nv_seed_poll( void *data,
+ }
+ #endif /* MBEDTLS_ENTROPY_NV_SEED */
+ 
++
++#ifdef __NDS__
++
++// libnds platform functions for entropy
++
++/*
++ * Seeder that uses libnds microphone access.
++ */
++
++#include <nds.h>
++#include <stdio.h>
++#include "mbedtls/entropy.h"
++
++static volatile int mic_done = 0;
++static void* volatile mic_buffer_loc;
++
++void seeder_nds_mic_callback(void* data, int length)
++{
++    ((void) length);
++    if(data != mic_buffer_loc)
++    {
++        soundMicOff();
++        mic_done = 1;
++    }
++}
++
++int mbedtls_hardware_poll( void *data, unsigned char *output, size_t len,
++                           size_t *olen )
++{
++    ((void) data);
++    *olen = 0;
++
++    mic_buffer_loc = output;
++    mic_done = 0;
++
++    // start recording from mic
++    if(!soundMicRecord(mic_buffer_loc, len, MicFormat_8Bit, 16000, seeder_nds_mic_callback))
++    {
++        return 0;
++    }
++
++    int irq_count = 0;
++
++    while(!mic_done)
++    {
++        if(irq_count == 60)
++        {
++            soundMicOff();
++            return( MBEDTLS_ERR_ENTROPY_SOURCE_FAILED );
++        }
++        swiWaitForVBlank();
++        irq_count++;
++    }
++
++    *olen = len;
++
++    return( 0 );
++}
++
++#endif // #ifdef __NDS__
++
+ #endif /* MBEDTLS_ENTROPY_C */
+diff --git a/library/net_sockets.c b/library/net_sockets.c
+index 17a9e4a..781eb95 100644
+--- a/library/net_sockets.c
++++ b/library/net_sockets.c
+@@ -33,7 +33,7 @@
+ 
+ #if !defined(unix) && !defined(__unix__) && !defined(__unix) && \
+     !defined(__APPLE__) && !defined(_WIN32) && !defined(__QNXNTO__) && \
+-    !defined(__HAIKU__) && !defined(__midipix__)
++    !defined(__HAIKU__) && !defined(__midipix__) && !defined(__NDS__)
+ #error "This module only works on Unix and Windows, see MBEDTLS_NET_C in mbedtls_config.h"
+ #endif
+ 
+@@ -168,6 +168,7 @@ void mbedtls_net_init( mbedtls_net_context *ctx )
+     ctx->fd = -1;
+ }
+ 
++#ifndef __NDS__ // getaddrinfo doesn't work on NDS
+ /*
+  * Initiate a TCP connection with host:port and the given protocol
+  */
+@@ -287,6 +288,7 @@ int mbedtls_net_bind( mbedtls_net_context *ctx, const char *bind_ip, const char
+     return( ret );
+ 
+ }
++#endif // #ifndef __NDS__ // getaddrinfo doesn't work on NDS
+ 
+ #if ( defined(_WIN32) || defined(_WIN32_WCE) ) && !defined(EFIX64) && \
+     !defined(EFI32)
+@@ -333,6 +335,7 @@ static int net_would_block( const mbedtls_net_context *ctx )
+ }
+ #endif /* ( _WIN32 || _WIN32_WCE ) && !EFIX64 && !EFI32 */
+ 
++#ifndef __NDS__ // IPv6 doesn't work on NDS
+ /*
+  * Accept a connection from a remote client
+  */
+@@ -451,6 +454,7 @@ int mbedtls_net_accept( mbedtls_net_context *bind_ctx,
+ 
+     return( 0 );
+ }
++#endif // #ifndef __NDS__ // IPv6 doesn't work on NDS
+ 
+ /*
+  * Set the socket blocking or non-blocking
+@@ -576,7 +580,11 @@ int mbedtls_net_recv( void *ctx, unsigned char *buf, size_t len )
+     if( ret != 0 )
+         return( ret );
+ 
++#ifndef __NDS__
+     ret = (int) read( fd, buf, len );
++#else
++    ret = (int) recv( fd, buf, len, 0 );
++#endif
+ 
+     if( ret < 0 )
+     {
+@@ -658,7 +666,11 @@ int mbedtls_net_send( void *ctx, const unsigned char *buf, size_t len )
+     if( ret != 0 )
+         return( ret );
+ 
++#ifndef __NDS__
+     ret = (int) write( fd, buf, len );
++#else
++    ret = (int) send( fd, buf, len, 0 );
++#endif
+ 
+     if( ret < 0 )
+     {
+diff --git a/library/timing.c b/library/timing.c
+index 8a02c00..9fc6b6b 100644
+--- a/library/timing.c
++++ b/library/timing.c
+@@ -27,7 +27,7 @@
+ 
+ #if !defined(unix) && !defined(__unix__) && !defined(__unix) && \
+     !defined(__APPLE__) && !defined(_WIN32) && !defined(__QNXNTO__) && \
+-    !defined(__HAIKU__) && !defined(__midipix__)
++    !defined(__HAIKU__) && !defined(__midipix__) && !defined(__NDS__)
+ #error "This module only works on Unix and Windows, see MBEDTLS_TIMING_C in mbedtls_config.h"
+ #endif
+ 


### PR DESCRIPTION
This is a bit of a "feature request" PR. I've made a very basic port of mbedtls and curl to dswifi / calico, and I'd love for this port to evolve into something well-supported and widely used, but I don't think that I personally have all of the skills needed to do so.

There may be some issues with my current implementation and needs more testing to be called "stable", but it may be of use to the community.

Here are the "interesting" features of my ports:

**mbedtls**:
* Disables the SSL server protocol
* Disables IPv6 and `getaddrinfo` (both of which are not included in functions called by libcurl
* Uses `recv` / `send` instead of `read` / `write` (I believe that the sgIP stack does not use a unified namespace for sockets and file descriptors?)

**curl**:
* Disables all protocols other than HTTP/HTTPS, FTP/FTPS, and FILE
* Uses `ioctl` instead of `sfcntl` (for same reason as above)
* Uses `closesocket` instead of `close` (by putting `${DEVKITPRO}/libnds/include/sys/` into the include path so that `socket.h` is detected)

Note that I listed Wintermute as a "maintainer" for the purposes of this PR but I am happy to change that if you like.

Finally note that these versions are both out of date. Unfortunately, current versions don't seem to work properly and I am not certain why. (Newer versions also increase the codesize significantly.)