### PR TITLE
ppc-libjpeg-turbo: Disable SIMD 

### DIFF
--- a/ppc/libjpeg-turbo/PKGBUILD
+++ b/ppc/libjpeg-turbo/PKGBUILD
@@ -26,7 +26,7 @@ build() {
 
   source /opt/devkitpro/ppcvars.sh
 
-  powerpc-eabi-cmake -DENABLE_SHARED:BOOLEAN=false -DWITH_TURBOJPEG_TESTS:BOOLEAN=false -DCMAKE_INSTALL_PREFIX=$PORTLIBS_PREFIX .
+  powerpc-eabi-cmake -DENABLE_SHARED:BOOLEAN=false -DWITH_TURBOJPEG_TESTS:BOOLEAN=false -DWITH_SIMD:BOOLEAN=false -DCMAKE_INSTALL_PREFIX=$PORTLIBS_PREFIX .
 
   make
 }


### PR DESCRIPTION
Prevents libjpeg-turbo from trying to use altivec
I am not knowledgeable enough to add paired singles support to the lib, but at least this makes it work.