### PR TITLE
Use `CMAKE_TOOLCHAIN_FILE` env var instead of passing as `-D` parameter

### DIFF
--- a/cmake/3ds/arm-none-eabi-cmake
+++ b/cmake/3ds/arm-none-eabi-cmake
@@ -1,4 +1,4 @@
 #!/usr/bin/env bash
 set -e
 
-exec cmake -DCMAKE_TOOLCHAIN_FILE=${DEVKITPRO}/cmake/3DS.cmake "$@"
+exec env CMAKE_TOOLCHAIN_FILE="${DEVKITPRO}/cmake/3DS.cmake" cmake "$@"

--- a/cmake/devkita64/aarch64-none-elf-cmake
+++ b/cmake/devkita64/aarch64-none-elf-cmake
@@ -1,4 +1,4 @@
 #!/usr/bin/env bash
 set -e
 
-exec cmake -DCMAKE_TOOLCHAIN_FILE=${DEVKITPRO}/cmake/devkitA64.cmake "$@"
+exec env CMAKE_TOOLCHAIN_FILE="${DEVKITPRO}/cmake/devkitA64.cmake" cmake "$@"

--- a/cmake/devkitarm/arm-none-eabi-cmake
+++ b/cmake/devkitarm/arm-none-eabi-cmake
@@ -1,4 +1,4 @@
 #!/usr/bin/env bash
 set -e
 
-exec cmake -DCMAKE_TOOLCHAIN_FILE=${DEVKITPRO}/cmake/devkitARM.cmake "$@"
+exec env CMAKE_TOOLCHAIN_FILE="${DEVKITPRO}/cmake/devkitARM.cmake" cmake "$@"

--- a/cmake/devkitppc/powerpc-eabi-cmake
+++ b/cmake/devkitppc/powerpc-eabi-cmake
@@ -1,4 +1,4 @@
 #!/usr/bin/env bash
 set -e
 
-exec cmake -DCMAKE_TOOLCHAIN_FILE=${DEVKITPRO}/cmake/devkitPPC.cmake "$@"
+exec env CMAKE_TOOLCHAIN_FILE="${DEVKITPRO}/cmake/devkitPPC.cmake" cmake "$@"

--- a/cmake/gamecube/powerpc-eabi-cmake
+++ b/cmake/gamecube/powerpc-eabi-cmake
@@ -1,4 +1,4 @@
 #!/usr/bin/env bash
 set -e
 
-exec cmake -DCMAKE_TOOLCHAIN_FILE=${DEVKITPRO}/cmake/GameCube.cmake "$@"
+exec env CMAKE_TOOLCHAIN_FILE="${DEVKITPRO}/cmake/GameCube.cmake" cmake "$@"

--- a/cmake/gba/arm-none-eabi-cmake
+++ b/cmake/gba/arm-none-eabi-cmake
@@ -1,4 +1,4 @@
 #!/usr/bin/env bash
 set -e
 
-exec cmake -DCMAKE_TOOLCHAIN_FILE=${DEVKITPRO}/cmake/GBA.cmake "$@"
+exec env CMAKE_TOOLCHAIN_FILE="${DEVKITPRO}/cmake/GBA.cmake" cmake "$@"

--- a/cmake/nds/arm-none-eabi-cmake
+++ b/cmake/nds/arm-none-eabi-cmake
@@ -1,4 +1,4 @@
 #!/usr/bin/env bash
 set -e
 
-exec cmake -DCMAKE_TOOLCHAIN_FILE=${DEVKITPRO}/cmake/NDS.cmake "$@"
+exec env CMAKE_TOOLCHAIN_FILE="${DEVKITPRO}/cmake/NDS.cmake" cmake "$@"

--- a/cmake/switch/aarch64-none-elf-cmake
+++ b/cmake/switch/aarch64-none-elf-cmake
@@ -1,4 +1,4 @@
 #!/usr/bin/env bash
 set -e
 
-exec cmake -DCMAKE_TOOLCHAIN_FILE=${DEVKITPRO}/cmake/Switch.cmake "$@"
+exec env CMAKE_TOOLCHAIN_FILE="${DEVKITPRO}/cmake/Switch.cmake" cmake "$@"

--- a/cmake/wii/powerpc-eabi-cmake
+++ b/cmake/wii/powerpc-eabi-cmake
@@ -1,4 +1,4 @@
 #!/usr/bin/env bash
 set -e
 
-exec cmake -DCMAKE_TOOLCHAIN_FILE=${DEVKITPRO}/cmake/Wii.cmake "$@"
+exec env CMAKE_TOOLCHAIN_FILE="${DEVKITPRO}/cmake/Wii.cmake" cmake "$@"

--- a/cmake/wiiu/powerpc-eabi-cmake
+++ b/cmake/wiiu/powerpc-eabi-cmake
@@ -1,4 +1,4 @@
 #!/usr/bin/env bash
 set -e
 
-exec cmake -DCMAKE_TOOLCHAIN_FILE=${DEVKITPRO}/cmake/WiiU.cmake "$@"
+exec env CMAKE_TOOLCHAIN_FILE="${DEVKITPRO}/cmake/WiiU.cmake" cmake "$@"


### PR DESCRIPTION
The `-D` option can't be used with some CMake subcommands, including `--build` and `--install`. 

Solves CLion not being able to build projects when the toolchain CMake path is set to one of the `<platform>-cmake` scripts.