### PR TITLE
feat(3ds-curl): enable websockets

### DIFF
--- a/3ds/curl/PKGBUILD
+++ b/3ds/curl/PKGBUILD
@@ -3,7 +3,7 @@
 
 pkgname=3ds-curl
 pkgver=8.4.0
-pkgrel=1
+pkgrel=2
 pkgdesc='Library for transferring data with URLs. (for Nintendo 3DS homebrew development)'
 arch=('any')
 url='https://curl.haxx.se'

--- a/3ds/curl/PKGBUILD
+++ b/3ds/curl/PKGBUILD
@@ -39,6 +39,7 @@ build() {
     --disable-pthreads \
     --disable-socketpair \
     --disable-ntlm-wb \
+    --enable-websockets \
     --with-mbedtls=${PORTLIBS_PREFIX} \
     --with-ca-bundle=sdmc:/config/ssl/cacert.pem
 


### PR DESCRIPTION
This only adds 7 kilobytes to the 3ds-curl package which is very little compared to the original 422 kilobytes before hand. Adding 7 kilobytes should not have very much effect on many applications. If you want I can turn this into it's own package.