### PR TITLE
PPC: update ppc-libogg to 1.3.6

### DIFF
--- a/ppc/libogg/PKGBUILD
+++ b/ppc/libogg/PKGBUILD
@@ -1,39 +1,46 @@
 # Maintainer:  Dave Murphy <davem@devkitpro.org>
 
-pkgname=ppc-libogg
-pkgver=1.3.4
+_pkgname=libogg
+pkgname=ppc-${_pkgname}
+pkgver=1.3.6
 pkgrel=1
-pkgdesc='The Ogg transport bitstream is designed to provide framing, error protection and seeking structure for higher-level codec streams that consist of raw, unencapsulated data packets, such as the Opus, Vorbis and FLAC audio codecs or the Theora and Dirac video codecs.'
+pkgdesc='Library to parse Ogg files.'
 arch=('any')
 url='https://wiki.xiph.org/Ogg'
 license=(Xiph.org)
-options=(!strip libtool staticlibs)
-source=("https://ftp.osuosl.org/pub/xiph/releases/ogg/libogg-$pkgver.tar.gz")
-sha256sums=('fe5670640bd49e828d64d2879c31cb4dde9758681bb664f9bdbf159a01b0c76e')
-makedepends=('ppc-pkg-config' 'dkp-toolchain-vars')
+options=(!buildflags !strip libtool staticlibs)
 groups=('ppc-portlibs')
+makedepends=(
+  'dkp-toolchain-vars'
+  'ppc-pkg-config'
+)
+source=("https://downloads.xiph.org/releases/ogg/${_pkgname}-${pkgver}.tar.gz")
+
 build() {
-  cd libogg-$pkgver
+  cd "${_pkgname}-$pkgver"
 
-  source /opt/devkitpro/devkitppc.sh
-  source /opt/devkitpro/ppcvars.sh
+  source "${DEVKITPRO}/ppcvars.sh"
 
-  ./configure --prefix="${PORTLIBS_PREFIX}" --host=powerpc-eabi \
-    --disable-shared --enable-static
+  ./configure \
+      --prefix="${PORTLIBS_PREFIX}" \
+      --host=powerpc-eabi \
+      --disable-shared \
+      --enable-static
 
   make
 }
 
 package() {
-  cd libogg-$pkgver
+  cd "${_pkgname}-$pkgver"
 
-  source /opt/devkitpro/devkitppc.sh
-  source /opt/devkitpro/ppcvars.sh
+  source "${DEVKITPRO}/ppcvars.sh"
 
-  make DESTDIR="$pkgdir" install
+  make install DESTDIR="$pkgdir"
 
-  install -Dm644 COPYING "$pkgdir"${PORTLIBS_PREFIX}/licenses/$pkgname/COPYING
+  install -Dm644 -t "${pkgdir}${PORTLIBS_PREFIX}/licenses/${pkgname}" COPYING
 
   # remove useless documentation
-  rm -r "$pkgdir"${PORTLIBS_PREFIX}/share/doc
+  rm -r "${pkgdir}${PORTLIBS_PREFIX}/share/doc"
 }
+
+sha256sums=('83e6704730683d004d20e21b8f7f55dcb3383cdf84c0daedf30bde175f774638')


### PR DESCRIPTION
This updates the ppc-libogg package to libogg 1.3.6