### PR TITLE
dkp-toolchain-vars: append to PATH

### DIFF
--- a/dkp-toolchain-vars/3dsvars.sh
+++ b/dkp-toolchain-vars/3dsvars.sh
@@ -1,10 +1,13 @@
-. ${DEVKITPRO}/devkitarm.sh
+source ${DEVKITPRO}/devkitarm.sh
 
 PORTLIBS_PREFIX=${PORTLIBS_ROOT}/3ds
-PATH=$PORTLIBS_PREFIX/bin:$PATH
+DKP_PATH=${PORTLIBS_PREFIX}/bin:${DKP_PATH}
 
 export CFLAGS="-march=armv6k -mtune=mpcore -mfloat-abi=hard -mtp=soft -O2 -mword-relocations -ffunction-sections -fdata-sections"
 export CXXFLAGS="${CFLAGS}"
 export CPPFLAGS="-D_3DS -D__3DS__ -I${PORTLIBS_PREFIX}/include -I${DEVKITPRO}/libctru/include"
 export LDFLAGS="-L${PORTLIBS_PREFIX}/lib -L${DEVKITPRO}/libctru/lib"
 export LIBS="-lctru"
+
+PATH=${PATH}:${DKP_PATH}
+unset DKP_PATH

--- a/dkp-toolchain-vars/PKGBUILD
+++ b/dkp-toolchain-vars/PKGBUILD
@@ -1,6 +1,6 @@
 # Maintainer: WinterMute <davem@devkitpro.org>
 pkgname=dkp-toolchain-vars
-pkgver=1.0.5
+pkgver=1.0.6
 pkgrel=1
 
 pkgdesc='helper scripts to set variables for devkitPro toolchains'
@@ -9,10 +9,18 @@ arch=('any')
 url='http://devkitpro.org/'
 
 source=(
-  'devkitarm.sh' '3dsvars.sh' 'ndsvars.sh' 'armv4tvars.sh'
-  'devkitppc.sh' 'ppcvars.sh' 'cubevars.sh' 'wiivars.sh' 'wiiuvars.sh'
-  'devkita64.sh' 'switchvars.sh'
+  '3dsvars.sh'
+  'armv4tvars.sh'
+  'cubevars.sh'
+  'devkita64.sh'
+  'devkitarm.sh'
+  'devkitppc.sh'
+  'ndsvars.sh'
   'portlibs_prefix.sh'
+  'ppcvars.sh'
+  'switchvars.sh'
+  'wiiuvars.sh'
+  'wiivars.sh'
 )
 
 conflicts=('devkitpro-pkgbuild-helpers')
@@ -20,24 +28,25 @@ conflicts=('devkitpro-pkgbuild-helpers')
 options=(!strip)
 
 package() {
+  install -d "${pkgdir}/opt/devkitpro/cmake"
 
-  install -d "$pkgdir"/opt/devkitpro/cmake
-  install -Dm644 devkitarm.sh 3dsvars.sh ndsvars.sh armv4tvars.sh "$pkgdir"/opt/devkitpro
-  install -Dm644 devkita64.sh switchvars.sh "$pkgdir"/opt/devkitpro
-  install -Dm644 devkitppc.sh ppcvars.sh cubevars.sh wiivars.sh wiiuvars.sh "$pkgdir"/opt/devkitpro
-  install -Dm755 portlibs_prefix.sh "$pkgdir"/opt/devkitpro
+  install -Dm644 -t "${pkgdir}/opt/devkitpro" \
+          devkitarm.sh 3dsvars.sh ndsvars.sh armv4tvars.sh \
+          devkita64.sh switchvars.sh \
+          devkitppc.sh ppcvars.sh cubevars.sh wiivars.sh wiiuvars.sh
 
+  install -Dm755 -t "${pkgdir}/opt/devkitpro" portlibs_prefix.sh
 }
 
-sha256sums=('000b49cce7a925cb096fbac43501ef1c89511861a3ea2091569ae71aa108369b'
-            '679c9e428c6ee6f482299679c1f0b576cec628afb145e19def497894864dd509'
-            '223f87989791295ef5170d33698390fb1389c4f3cfad735f47fec5757f13c452'
-            '7bc0176c5dbea1ab6acaa98a055a1ab81989152d68b582fc57612972f394ac07'
-            'b69edeee95dfece986941531a7e2c314cc550ab578b300997e0d5de9e825597c'
-            'e3156d1e6671bfc9ad6a343d26da8cbddcfc4d8e5321ddc07cb2b4934e20ed66'
-            '004fd94dfc9e7a19281fec19c0341686f4dbf00d1f3c9c5590a150e1faac2360'
-            'e35283a019b5e032c8085e3085b46ab80cea58851c087ba4269a502195ade359'
-            '0f096b32a3216916553360948d2f91f92f4657844a1618cb84bf96a797c44979'
-            'f3caba3a8864a31a50ff50131f39d160013b6d0b8a2e7e6ac90ca44b591fcb57'
-            '5ade1211e616a7eb540c3660839d17af050c41c7c9ee89242ce4fe7afac4df52'
-            '7913cb3d38e78ede19673912f25970d678912404399e5c10c744726bbafd5f84')
+sha256sums=('0703e516af61d0ba19544b872c40b47df856af0eee9b2100ea0b7d0240aeaba0'
+            'f6e3d527bd8ff0acdcd6e0513c2fef3b16cb2a02dd3977ad5bfc4d0a39854117'
+            'c473dce11d9168cf3ef4a6c97ac414283e8ad9c8cfcbd2c7ef54e37d46d1aa49'
+            '6b6b684941f7d72dbf67e07fc13432c9d377a313bd8240d1e333e523db97bb5d'
+            '6710d3650879d587546cf6d81246b9e23b884072a6e5785288c8da4d85df304b'
+            'b346347a9ed184f68d24ec7daf68b2d81872eebb672bb01f1032c5211479898f'
+            'd0b3c7a5f21b89c00344587dcfa62e28f95cc0cf3a1aea136921bd74ae8dcb72'
+            '7913cb3d38e78ede19673912f25970d678912404399e5c10c744726bbafd5f84'
+            '47e1277dfa760a3609a54a4ab03cf14c12762523c38ae480cbfb0eab6292730e'
+            '142bf14d1c997212b0fc2720134302ceb3957a247fef85d10a0f34ce32361b17'
+            '2121714135a10d02ea30ee5c5a7b8f2fafefe5c2165cb3dc0e5350cfbccd3b07'
+            '51e325721e36f978d58c9fe1cd8c6a624a6f5610a648238531d551a847ae40ec')

--- a/dkp-toolchain-vars/armv4tvars.sh
+++ b/dkp-toolchain-vars/armv4tvars.sh
@@ -1,10 +1,13 @@
-. ${DEVKITPRO}/devkitarm.sh
+source ${DEVKITPRO}/devkitarm.sh
 
 PORTLIBS_PREFIX=${PORTLIBS_ROOT}/armv4t
-PATH=$PORTLIBS_PREFIX/bin:$PATH
+DKP_PATH=${PORTLIBS_PREFIX}/bin:${DKP_PATH}
 
 export CFLAGS="-march=armv4t -O2 -ffunction-sections -fdata-sections"
 export CXXFLAGS="${CFLAGS}"
 export CPPFLAGS="-I${PORTLIBS_PREFIX}/include"
 export LDFLAGS="-L${PORTLIBS_PREFIX}/lib"
 export LIBS=""
+
+PATH=${PATH}:${DKP_PATH}
+unset DKP_PATH

--- a/dkp-toolchain-vars/cubevars.sh
+++ b/dkp-toolchain-vars/cubevars.sh
@@ -1,12 +1,14 @@
-. ${DEVKITPRO}/devkitppc.sh
+source ${DEVKITPRO}/devkitppc.sh
 
-export PORTLIBS_PREFIX=${PORTLIBS_ROOT}/gamecube
 export PORTLIBS_PPC=${PORTLIBS_ROOT}/ppc
-export PORTLIBS_CUBE=${PORTLIBS_PREFIX}
+export PORTLIBS_CUBE=${PORTLIBS_ROOT}/gamecube
+export PORTLIBS_PREFIX=${PORTLIBS_CUBE}
+DKP_PATH=${PORTLIBS_CUBE}/bin:${PORTLIBS_PPC}/bin:${DKP_PATH}
 
 export CFLAGS="-O2 -mogc -mcpu=750 -meabi -mhard-float -ffunction-sections -fdata-sections"
 export CXXFLAGS="${CFLAGS}"
 export CPPFLAGS="-D__GAMECUBE__ -I${DEVKITPRO}/libogc/include -I${PORTLIBS_CUBE}/include -I${PORTLIBS_PPC}/include"
 export LDFLAGS="-L${PORTLIBS_CUBE}/lib -L${PORTLIBS_PPC}/lib"
 
-export PATH=${PORTLIBS_CUBE}/bin:${PORTLIBS_PPC}/bin:$PATH
+PATH=${PATH}:${DKP_PATH}
+unset DKP_PATH

--- a/dkp-toolchain-vars/devkita64.sh
+++ b/dkp-toolchain-vars/devkita64.sh
@@ -1,9 +1,9 @@
-#!/usr/bin/env bash
 export DEVKITPRO=/opt/devkitpro
 export PORTLIBS_ROOT=${DEVKITPRO}/portlibs
-export PATH=${DEVKITPRO}/tools/bin:${DEVKITPRO}/devkitA64/bin:$PATH
 export TOOL_PREFIX=aarch64-none-elf-
 export CC=${TOOL_PREFIX}gcc
 export CXX=${TOOL_PREFIX}g++
 export AR=${TOOL_PREFIX}gcc-ar
 export RANLIB=${TOOL_PREFIX}gcc-ranlib
+
+DKP_PATH=${DEVKITPRO}/tools/bin:${DEVKITPRO}/devkitA64/bin${DKP_PATH:+:${DKP_PATH}}

--- a/dkp-toolchain-vars/devkitarm.sh
+++ b/dkp-toolchain-vars/devkitarm.sh
@@ -1,10 +1,10 @@
-#!/usr/bin/env bash
 export DEVKITPRO=/opt/devkitpro
 export DEVKITARM=${DEVKITPRO}/devkitARM
 export PORTLIBS_ROOT=${DEVKITPRO}/portlibs
-export PATH=${DEVKITPRO}/tools/bin:$DEVKITARM/bin:$PATH
 export TOOL_PREFIX=arm-none-eabi-
 export CC=${TOOL_PREFIX}gcc
 export CXX=${TOOL_PREFIX}g++
 export AR=${TOOL_PREFIX}gcc-ar
 export RANLIB=${TOOL_PREFIX}gcc-ranlib
+
+DKP_PATH=${DEVKITPRO}/tools/bin:${DEVKITARM}/bin${DKP_PATH:+:${DKP_PATH}}

--- a/dkp-toolchain-vars/devkitppc.sh
+++ b/dkp-toolchain-vars/devkitppc.sh
@@ -1,10 +1,10 @@
-#!/usr/bin/env bash
 export DEVKITPRO=/opt/devkitpro
 export DEVKITPPC=${DEVKITPRO}/devkitPPC
 export PORTLIBS_ROOT=${DEVKITPRO}/portlibs
-export PATH=${DEVKITPRO}/tools/bin:${DEVKITPRO}/devkitPPC/bin:$PATH
 export TOOL_PREFIX=powerpc-eabi-
 export CC=${TOOL_PREFIX}gcc
 export CXX=${TOOL_PREFIX}g++
 export AR=${TOOL_PREFIX}gcc-ar
 export RANLIB=${TOOL_PREFIX}gcc-ranlib
+
+DKP_PATH=${DEVKITPRO}/tools/bin:${DEVKITPRO}/devkitPPC/bin${DKP_PATH:+:${DKP_PATH}}

--- a/dkp-toolchain-vars/ndsvars.sh
+++ b/dkp-toolchain-vars/ndsvars.sh
@@ -1,10 +1,13 @@
-. ${DEVKITPRO}/devkitarm.sh
+source ${DEVKITPRO}/devkitarm.sh
 
 PORTLIBS_PREFIX=${PORTLIBS_ROOT}/nds
-PATH=$PORTLIBS_PREFIX/bin:$PATH
+DKP_PATH=${PORTLIBS_PREFIX}/bin:${DKP_PATH}
 
 export CFLAGS="-march=armv5te -mtune=arm946e-s -O2 -ffunction-sections -fdata-sections"
 export CXXFLAGS="${CFLAGS}"
 export CPPFLAGS="-D__NDS__ -DARM9 -I${PORTLIBS_PREFIX}/include -I${DEVKITPRO}/libnds/include"
 export LDFLAGS="-L${PORTLIBS_PREFIX}/lib -L${DEVKITPRO}/libnds/lib"
 export LIBS="-lnds9"
+
+PATH=${PATH}:${DKP_PATH}
+unset DKP_PATH

--- a/dkp-toolchain-vars/ppcvars.sh
+++ b/dkp-toolchain-vars/ppcvars.sh
@@ -1,10 +1,12 @@
-. ${DEVKITPRO}/devkitppc.sh
+source ${DEVKITPRO}/devkitppc.sh
 
 export PORTLIBS_PREFIX=${PORTLIBS_ROOT}/ppc
+DKP_PATH=${PORTLIBS_PREFIX}/bin:${DKP_PATH}
 
 export CFLAGS="-O2 -mcpu=750 -meabi -mhard-float -ffunction-sections -fdata-sections"
 export CXXFLAGS="${CFLAGS}"
 export CPPFLAGS="-I${PORTLIBS_PREFIX}/include"
 export LDFLAGS="-L${PORTLIBS_PREFIX}/lib"
 
-export PATH=${PORTLIBS_PREFIX}/bin:$PATH
+PATH=${PATH}:${DKP_PATH}
+unset DKP_PATH

--- a/dkp-toolchain-vars/switchvars.sh
+++ b/dkp-toolchain-vars/switchvars.sh
@@ -1,7 +1,7 @@
-. ${DEVKITPRO}/devkita64.sh
+source ${DEVKITPRO}/devkita64.sh
 
 export PORTLIBS_PREFIX=${DEVKITPRO}/portlibs/switch
-export PATH=$PORTLIBS_PREFIX/bin:$PATH
+DKP_PATH=${PORTLIBS_PREFIX}/bin:${DKP_PATH}
 
 export ARCH="-march=armv8-a+crc+crypto -mtune=cortex-a57 -mtp=soft -fPIC -ftls-model=local-exec"
 export CFLAGS="${ARCH} -O2 -ffunction-sections -fdata-sections"
@@ -9,3 +9,6 @@ export CXXFLAGS="${CFLAGS}"
 export CPPFLAGS="-D__SWITCH__ -I${PORTLIBS_PREFIX}/include -isystem ${DEVKITPRO}/libnx/include"
 export LDFLAGS="${ARCH} -L${PORTLIBS_PREFIX}/lib -L${DEVKITPRO}/libnx/lib"
 export LIBS="-lnx"
+
+PATH=${PATH}:${DKP_PATH}
+unset DKP_PATH

--- a/dkp-toolchain-vars/wiiuvars.sh
+++ b/dkp-toolchain-vars/wiiuvars.sh
@@ -1,8 +1,9 @@
-. ${DEVKITPRO}/devkitppc.sh
+source ${DEVKITPRO}/devkitppc.sh
 
-export PORTLIBS_PREFIX=${PORTLIBS_ROOT}/wiiu
 export PORTLIBS_PPC=${PORTLIBS_ROOT}/ppc
-export PORTLIBS_WIIU=${PORTLIBS_PREFIX}
+export PORTLIBS_WIIU=${PORTLIBS_ROOT}/wiiu
+export PORTLIBS_PREFIX=${PORTLIBS_WIIU}
+DKP_PATH=${PORTLIBS_WIIU}/bin:${PORTLIBS_PPC}/bin:${DKP_PATH}
 
 export CFLAGS="-mcpu=750 -meabi -mhard-float -O2 -ffunction-sections -fdata-sections"
 export CXXFLAGS="${CFLAGS}"
@@ -10,4 +11,5 @@ export CPPFLAGS="-DESPRESSO -D__WIIU__ -D__WUT__ -I${PORTLIBS_WIIU}/include -I${
 export LDFLAGS="-L${PORTLIBS_WIIU}/lib -L${PORTLIBS_PPC}/lib -L${DEVKITPRO}/wut/lib -specs=${DEVKITPRO}/wut/share/wut.specs"
 export LIBS="-lwut -lm"
 
-export PATH=${PORTLIBS_WIIU}/bin:${PORTLIBS_PPC}/bin:$PATH
+PATH=${PATH}:${DKP_PATH}
+unset DKP_PATH

--- a/dkp-toolchain-vars/wiivars.sh
+++ b/dkp-toolchain-vars/wiivars.sh
@@ -1,8 +1,9 @@
-. ${DEVKITPRO}/devkitppc.sh
+source ${DEVKITPRO}/devkitppc.sh
 
-export PORTLIBS_PREFIX=${PORTLIBS_ROOT}/wii
 export PORTLIBS_PPC=${PORTLIBS_ROOT}/ppc
-export PORTLIBS_WII=${PORTLIBS_PREFIX}
+export PORTLIBS_WII=${PORTLIBS_ROOT}/wii
+export PORTLIBS_PREFIX=${PORTLIBS_WII}
+DKP_PATH=${PORTLIBS_WII}/bin:${PORTLIBS_PPC}/bin:${DKP_PATH}
 
 export CFLAGS="-O2 -mrvl -mcpu=750 -meabi -mhard-float -ffunction-sections -fdata-sections"
 export CXXFLAGS="${CFLAGS}"
@@ -10,4 +11,5 @@ export CPPFLAGS="-D__WII__ -I${DEVKITPRO}/libogc/include -I${PORTLIBS_WII}/inclu
 export LDFLAGS="-L${PORTLIBS_WII}/lib -L${PORTLIBS_PPC}/lib -L${DEVKITPRO}/libogc/lib/wii"
 export LIBS="-logc -lm"
 
-export PATH=${PORTLIBS_WII}/bin:${PORTLIBS_PPC}/bin:$PATH
+PATH=${PATH}:${DKP_PATH}
+unset DKP_PATH


### PR DESCRIPTION
This changes the `PATH` variable to be appended instead of prepended.

The motivation is to not break the typical ccache setup, where a ccache link appears in `PATH` before the real compiler. If we append to `PATH`, ccache works as intended; if we prepend to `PATH`, ccache is ignored.

## Tests

Here I compare the values of `PATH` output, to show the dkp paths are all preserved relative to each other:

### 3dsvars.sh

Before:

    /opt/devkitpro/portlibs/3ds/bin:/opt/devkitpro/tools/bin:/opt/devkitpro/devkitARM/bin:<ORIGINAL-PATH>

After:

    <ORIGINAL-PATH>:/opt/devkitpro/portlibs/3ds/bin:/opt/devkitpro/tools/bin:/opt/devkitpro/devkitARM/bin

### armv4tvars.sh 

Before:

    /opt/devkitpro/portlibs/armv4t/bin:/opt/devkitpro/tools/bin:/opt/devkitpro/devkitARM/bin:<ORIGINAL-PATH>

After:

    <ORIGINAL-PATH>:/opt/devkitpro/portlibs/armv4t/bin:/opt/devkitpro/tools/bin:/opt/devkitpro/devkitARM/bin

### cubevars.sh

Before:

    /opt/devkitpro/portlibs/gamecube/bin:/opt/devkitpro/portlibs/ppc/bin:/opt/devkitpro/tools/bin:/opt/devkitpro/devkitPPC/bin:<ORIGINAL-PATH>

After:

    <ORIGINAL-PATH>:/opt/devkitpro/portlibs/gamecube/bin:/opt/devkitpro/portlibs/ppc/bin:/opt/devkitpro/tools/bin:/opt/devkitpro/devkitPPC/bin

### ndsvars.sh

Before:

    /opt/devkitpro/portlibs/nds/bin:/opt/devkitpro/tools/bin:/opt/devkitpro/devkitARM/bin:<ORIGINAL-PATH>

After:

    <ORIGINAL-PATH>:/opt/devkitpro/portlibs/nds/bin:/opt/devkitpro/tools/bin:/opt/devkitpro/devkitARM/bin

### ppcvars.sh

Before:

    /opt/devkitpro/portlibs/ppc/bin:/opt/devkitpro/tools/bin:/opt/devkitpro/devkitPPC/bin:<ORIGINAL-PATH>

After:

    <ORIGINAL-PATH>:/opt/devkitpro/portlibs/ppc/bin:/opt/devkitpro/tools/bin:/opt/devkitpro/devkitPPC/bin

### switchvars.sh

Before:

    /opt/devkitpro/portlibs/switch/bin:/opt/devkitpro/tools/bin:/opt/devkitpro/devkitA64/bin:<ORIGINAL-PATH>

After:

    <ORIGINAL-PATH>:/opt/devkitpro/portlibs/switch/bin:/opt/devkitpro/tools/bin:/opt/devkitpro/devkitA64/bin

### wiiuvars.sh

Before:

    /opt/devkitpro/portlibs/wiiu/bin:/opt/devkitpro/portlibs/ppc/bin:/opt/devkitpro/tools/bin:/opt/devkitpro/devkitPPC/bin:<ORIGINAL-PATH>

After:

    <ORIGINAL-PATH>:/opt/devkitpro/portlibs/wiiu/bin:/opt/devkitpro/portlibs/ppc/bin:/opt/devkitpro/tools/bin:/opt/devkitpro/devkitPPC/bin

### wiivars.sh

Before:

    /opt/devkitpro/portlibs/wii/bin:/opt/devkitpro/portlibs/ppc/bin:/opt/devkitpro/tools/bin:/opt/devkitpro/devkitPPC/bin:<ORIGINAL-PATH>

After:

    <ORIGINAL-PATH>:/opt/devkitpro/portlibs/wii/bin:/opt/devkitpro/portlibs/ppc/bin:/opt/devkitpro/tools/bin:/opt/devkitpro/devkitPPC/bin
