### PR TITLE
PPC: update libpng to 1.6.55

### DIFF
--- a/ppc/libpng/PKGBUILD
+++ b/ppc/libpng/PKGBUILD
@@ -4,7 +4,7 @@
 
 _libname=libpng
 pkgname=ppc-${_libname}
-pkgver=1.6.54
+pkgver=1.6.55
 pkgrel=1
 pkgdesc='PNG format graphic files library (for Nintendo Gamecube/Wii homebrew development)'
 arch=('any')
@@ -49,4 +49,4 @@ package() {
   rm -r "${pkgdir}${PORTLIBS_PREFIX}/share"
 }
 
-sha256sums=('472db714567391842e410090df5a37e0f5b2ec67148a3007678b0482d2ba5219')
+sha256sums=('4b0abab6d219e95690ebe4db7fc9aa95f4006c83baaa022373c0c8442271283d')


### PR DESCRIPTION
This updates ppc-libpng to 1.6.55.