### PR TITLE
3ds-libopus, 3ds-opusfile: Build with fixed-point

### DIFF
--- a/3ds/libopus/PKGBUILD
+++ b/3ds/libopus/PKGBUILD
@@ -2,7 +2,7 @@
 
 pkgname=3ds-libopus
 pkgver=1.4
-pkgrel=1
+pkgrel=2
 pkgdesc='Reference implementation of the lossy audio codec, Opus'
 arch=('any')
 url='https://opus-codec.org/'
@@ -19,7 +19,7 @@ build() {
   source /opt/devkitpro/3dsvars.sh
 
   ./configure --prefix="${PORTLIBS_PREFIX}" --host=arm-none-eabi \
-    --disable-shared --enable-static
+    --disable-shared --enable-static --enable-fixed-point --disable-rtcd
 
   make
 }

--- a/3ds/opusfile/PKGBUILD
+++ b/3ds/opusfile/PKGBUILD
@@ -2,7 +2,7 @@
 
 pkgname=3ds-opusfile
 pkgver=0.11
-pkgrel=1
+pkgrel=2
 pkgdesc='Library for opening, seeking, and decoding .opus files'
 arch=('any')
 url='https://opus-codec.org/'
@@ -20,7 +20,7 @@ build() {
   source /opt/devkitpro/3dsvars.sh
 
   ./configure --prefix="${PORTLIBS_PREFIX}" --host=arm-none-eabi \
-    --disable-shared --enable-static
+    --disable-shared --enable-static --enable-fixed-point --disable-float
 
   make
 }


### PR DESCRIPTION
According to my crude testing, the fixed-point version of libopus is roughly twice as fast as the default floating-point version on 3DS.