### PR TITLE
ppc-libgd: 2.3.3-3

### DIFF
--- a/ppc/libgd/PKGBUILD
+++ b/ppc/libgd/PKGBUILD
@@ -3,7 +3,7 @@
 
 pkgname=ppc-libgd
 pkgver=2.3.3
-pkgrel=2
+pkgrel=3
 pkgdesc="Library for the dynamic creation of images"
 url="https://libgd.github.io"
 license=("custom")


### PR DESCRIPTION
We need to trigger a new build to be compatible with latest libjpegturbo again.  With latest libturbojpeg package update it's `jpeg_compress_struct` struct changed.